### PR TITLE
#21 Implemented better usability of measurements.

### DIFF
--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -260,5 +260,15 @@ class AtlasMeasurement(object):
                     period=self.period, granularity=self.granularity, measurements_count=self.measurements_count
                     )
 
+    def __hash__(self):
+        return hash(self.name+'-'+self.period)
 
+    def __eq__(self, other):
+        """
+        Measurements are considered duplicate of name and period are the same
+        :param other:
+        :return:
+        """
+        if isinstance(other, AtlasMeasurement):
+            return  ((self.name == other.name) and (self.period == other.period))
 OptionalAtlasMeasurement = NewType('OptionalAtlasMeasurement', Optional[AtlasMeasurement])

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -37,10 +37,11 @@ from typing import Optional, NewType, List, Any
 from datetime import datetime
 import isodate
 from atlasapi.measurements import AtlasMeasurement
-
+import logging
 from future import standard_library
 
 standard_library.install_aliases()
+logger = logging.getLogger('Atlas.specs')
 
 
 # etc., as needed
@@ -86,8 +87,19 @@ class Host(object):
             self.port = data.get("port", None)
             self.replica_set_name = data.get("replicaSetName", None)
             self.type = ReplicaSetTypes[data.get("typeName", "NO_DATA")]
-            self.measurements = None
+            self.measurements = []
             self.cluster_name = self.hostname.split('-')[0]
+
+    def add_measurements(self, measurement):
+        # TODO: Make measurements unique, use a set instead, but then how do we concat 2?
+        self.measurements = self.measurements + measurement
+
+    def __hash__(self):
+        return hash(self.hostname)
+
+    def __eq__(self, other):
+        if isinstance(other, Host):
+            return self.hostname == other.hostname
 
 
 ListOfHosts = NewType('ListOfHosts', List[Optional[Host]])
@@ -141,7 +153,7 @@ class DatabaseUsersPermissionsSpecs:
 
         return content
 
-    def add_roles(self, databaseName: str, roleNames: List[RoleSpecs], collectionName: str =None):
+    def add_roles(self, databaseName: str, roleNames: List[RoleSpecs], collectionName: str = None):
         """Add multiple roles
 
         Args:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='atlasapi',
-    version='0.7.0',
+    version='0.8.0',
     python_requires='>=3.6',
     packages=find_packages(),
     install_requires=['requests', 'python-dateutil', 'isodate', 'future', 'pytz'],

--- a/tests/monitoring_logs.py
+++ b/tests/monitoring_logs.py
@@ -13,6 +13,7 @@ from pprint import pprint
 from os import environ, getenv
 
 from atlasapi.specs import ListOfHosts, Host
+
 USER = getenv('ATLAS_USER', None)
 API_KEY = getenv('ATLAS_KEY', None)
 GROUP_ID = getenv('ATLAS_GROUP', None)
@@ -23,34 +24,60 @@ if not USER or not API_KEY or not GROUP_ID:
     raise EnvironmentError('In order to run this smoke test you need ATLAS_USER, AND ATLAS_KEY env variables'
                            'your env variables are {}'.format(environ.__str__()))
 
-a = Atlas(USER,API_KEY,GROUP_ID)
+a = Atlas(USER, API_KEY, GROUP_ID)
 
 # Low level Api
-#details = a.Hosts._get_all_hosts(pageNum=1, itemsPerPage=100)
-#pprint(details)
-#print('-----------------Now as iterable ------------------')
+# details = a.Hosts._get_all_hosts(pageNum=1, itemsPerPage=100)
+# pprint(details)
+# print('-----------------Now as iterable ------------------')
 # Iterable
-#for a_host in a.Hosts.host_names:
+# for a_host in a.Hosts.host_names:
 #    print(a_host)
 
 pprint('----------MeasureMents')
-output = a.Hosts._get_measurement_for_host(a.Hosts.host_list[0]
-                                           ,measurement=AtlasMeasurementTypes.Memory.virtual,iterable=True
-                                           ,period=AtlasPeriods.HOURS_24,granularity=AtlasGranularities.MINUTE)
 
-for each in output[0].measurements:
-    pprint(each.__dict__)
-pprint('------------Test list of clusters-----------------')
+# a.Hosts._get_measurement_for_host(a.Hosts.host_list[0]
+#                                           ,measurement=AtlasMeasurementTypes.Memory.virtual,iterable=True
+#                                           ,period=AtlasPeriods.HOURS_24,granularity=AtlasGranularities.MINUTE)
+#
+# a.Hosts._get_measurement_for_host(a.Hosts.host_list[0]
+#                                           ,measurement=AtlasMeasurementTypes.Memory.resident,iterable=True
+#                                           ,period=AtlasPeriods.HOURS_24,granularity=AtlasGranularities.MINUTE)
+#
+# a.Hosts._get_measurement_for_host(a.Hosts.host_list[1]
+#                                           ,measurement=AtlasMeasurementTypes.Memory.virtual,iterable=True
+#                                           ,period=AtlasPeriods.HOURS_24,granularity=AtlasGranularities.MINUTE)
+#
+# a.Hosts._get_measurement_for_host(a.Hosts.host_list[0]
+#                                           ,measurement=AtlasMeasurementTypes.Memory.virtual,iterable=True
+#                                           ,period=AtlasPeriods.HOURS_24,granularity=AtlasGranularities.MINUTE)
+#
+#
+# print(len(a.Hosts.host_list))
+#
+# for each in a.Hosts.host_list:
+#    print('Hostname: {} - Measurements: {}'.format(each.hostname, each.measurements))
+# pprint('------------Test list of clusters-----------------')
+#
+# cluster_list = a.Hosts.cluster_list
 
-cluster_list = a.Hosts.cluster_list
-
-for cluster in cluster_list:
-    print('Cluster name {}'.format(cluster))
+# for cluster in cluster_list:
+#    print('Cluster name {}'.format(cluster))
 
 
 pprint('------------Test get hosts by cluster-----------------')
 
-hosts = a.Hosts.host_list_by_cluster('monitoringtest')
+# hosts = a.Hosts.host_list_by_cluster('monitoringtest')
 
-for hosts in hosts:
-    pprint(hosts.__dict__)
+print('-----------Test get metrics for a clusters hosts---------------')
+a.Hosts.fill_host_list(for_cluster='monitoringtest')
+
+a.Hosts.get_measurement_for_hosts(measurement=AtlasMeasurementTypes.Memory.virtual
+                                  , period=AtlasPeriods.HOURS_24, granularity=AtlasGranularities.MINUTE)
+a.Hosts.get_measurement_for_hosts(measurement=AtlasMeasurementTypes.Memory.resident
+                                   , period=AtlasPeriods.HOURS_24, granularity=AtlasGranularities.MINUTE)
+
+for host in a.Hosts.host_list:
+    pprint(host.cluster_name)
+    for each_measurement in host.measurements:
+        pprint(each_measurement)


### PR DESCRIPTION
Breaking change. Now the _get_measurement_for_host is deprecated,
favoring the get_measurement_for_hosts method.

The metrics process now requires that the `fill_host_list` method to be called to fill the host list.  `host_list` was previously a generated property. This needed to be changed to allow the `Host` instances to be updated with multiple `measurement` objects.