### PR TITLE
66 restore to other group

### DIFF
--- a/atlasapi/__init__.py
+++ b/atlasapi/__init__.py
@@ -15,4 +15,4 @@
 # __init__.py
 
 # Version of the realpython-reader package
-__version__ = "0.13.1"
+__version__ = "0.13.2"

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -1529,7 +1529,7 @@ class Atlas:
 
         def request_snapshot_restore_to_group(self, source_cluster_name: str, snapshot_id: str,
                                               target_cluster_name: str,
-                                              target_group_obj: Atlas,
+                                              target_group_obj,
                                               delivery_type: DeliveryType = DeliveryType.automated
 
                                               ) -> SnapshotRestoreResponse:

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -66,7 +66,6 @@ class Atlas:
 
         # Network calls which will handled user/password for auth
         self.network = Network(user, password, auth_method)
-
         # APIs
         self.DatabaseUsers = Atlas._DatabaseUsers(self)
         self.Clusters = Atlas._Clusters(self)
@@ -1528,9 +1527,79 @@ class Atlas:
                 raise e
             return response_obj
 
+        def request_snapshot_restore_to_group(self, source_cluster_name: str, snapshot_id: str,
+                                              target_cluster_name: str,
+                                              target_group_obj: Atlas,
+                                              delivery_type: DeliveryType = DeliveryType.automated
+
+                                              ) -> SnapshotRestoreResponse:
+            """Requests a snapshot restore to another group/project.
+
+            Uses the passed target_group_obj, which is an Atlas object, to restore a snapshot from one group/project
+            to another.
+
+            This method does not check if the source and destination clusters have the same name, since this would
+            not be dangerous when these are in two groups.
+
+            Args:
+                source_cluster_name: the text name of the source cluster
+                snapshot_id: the uuid id of the snapshot to be restored
+                target_cluster_name: the txt name of the destination cluster
+                target_group_obj: Atlas: An Atlas object connected to the destination group.
+                delivery_type: DeliveryType: IF you want to download, or automatically restore on Atlas.
+
+            Returns:
+
+            """
+            # Check if the source and target groups are actually the same....
+            if target_group_obj.atlas.group == self.atlas.group:
+                txt = f"The source and target groups are the same ({self.atlas.group}). this method should only " \
+                      f"be used if the restore is to anothe group than the target."
+                logger.error(txt)
+                raise AttributeError(txt)
+
+            # Check if the target_cluster_name is valid
+            if not target_group_obj.atlas.Clusters.is_existing_cluster(target_cluster_name):
+                logger.error(f'The passed target cluster {target_cluster_name}, does not exist in this project.)')
+                raise ValueError(f'The passed target cluster {target_cluster_name}, does not exist in this project.')
+            else:
+                logger.info('The target cluster exists in the other target group.')
+            # Check if the snapshot_id is valid
+            if not self.atlas.CloudBackups.is_existing_snapshot(source_cluster_name, snapshot_id):
+                error_text = f'The passed snapshot_id ({snapshot_id} ' \
+                             f'is not valid for the source cluster {source_cluster_name})'
+                logger.error(error_text)
+                raise ValueError(error_text)
+            else:
+                logger.info('The snapshot_id is valid')
+
+            uri = Settings.api_resources["Cloud Backup Restore Jobs"]["Restore snapshot by cluster"] \
+                .format(GROUP_ID=self.atlas.group, CLUSTER_NAME=source_cluster_name)
+
+            request_obj = SnapshotRestore(delivery_type, snapshot_id, target_cluster_name, target_group_obj.atlas.group)
+
+            try:
+                response = self.atlas.network.post(uri=Settings.BASE_URL + uri, payload=request_obj.as_dict)
+            except ErrAtlasBadRequest as e:
+                if e.details.get('errorCode') == 'CLUSTER_RESTORE_IN_PROGRESS_CANNOT_UPDATE':
+                    logger.error(e.details)
+                    raise ErrAtlasRestoreConflictError(c=400, details=e.details)
+                else:
+                    logger.error('Received an Atlas bad request on Snapshot restore request.')
+                    logger.error(e.details)
+                    raise IOError("Received an Atlas bad request on Snapshot restore request.")
+
+            try:
+                response_obj = SnapshotRestoreResponse.from_dict(response)
+            except KeyError as e:
+                logger.error('Error encountered parsing response to a SnapshotRestoreResponse')
+                logger.error(e)
+                raise e
+            return response_obj
+
         # Get all Cloud Backup restore jobs by cluster
         def get_snapshot_restore_requests(self, cluster_name: str, restore_id: str = None, as_obj: bool = True) \
-                -> Union[List [Union[dict,SnapshotRestoreResponse]], SnapshotRestoreResponse, dict]:
+                -> Union[List[Union[dict, SnapshotRestoreResponse]], SnapshotRestoreResponse, dict]:
 
             if not restore_id:
                 uri = Settings.api_resources["Cloud Backup Restore Jobs"][
@@ -1576,20 +1645,22 @@ class Atlas:
             """
             # First Check if the restore_id is valid
             restore_info_result: SnapshotRestoreResponse = \
-                self.get_snapshot_restore_requests(cluster_name=cluster_name,restore_id=restore_id,as_obj=True)
+                self.get_snapshot_restore_requests(cluster_name=cluster_name, restore_id=restore_id, as_obj=True)
             restore_info = list(restore_info_result)[0]
             if not restore_info:
-                raise ErrAtlasNotFound(404,{"error": f"The passed restore_id {restore_id} was not found"})
+                raise ErrAtlasNotFound(404, {"error": f"The passed restore_id {restore_id} was not found"})
 
             elif restore_info.finished_at:
-                raise ErrAtlasBadRequest(500,{"error": f"The passed restore_id ({restore_id} has already been completed"
-                                                       f"and can not be canceled"})
+                raise ErrAtlasBadRequest(500,
+                                         {"error": f"The passed restore_id ({restore_id} has already been completed"
+                                                   f"and can not be canceled"})
             elif restore_info.cancelled is True:
                 raise ErrAtlasConflict(500,
-                                         {"error": f"The passed restore_id ({restore_id} has already been canceled"})
+                                       {"error": f"The passed restore_id ({restore_id} has already been canceled"})
 
             else:
-                uri = Settings.api_resources["Cloud Backup Restore Jobs"]["Cancel manual download restore job by job_id"] \
+                uri = Settings.api_resources["Cloud Backup Restore Jobs"][
+                    "Cancel manual download restore job by job_id"] \
                     .format(GROUP_ID=self.atlas.group, CLUSTER_NAME=cluster_name, JOB_ID=restore_id)
                 logger.info(f'Preparing to cancel snapshot {restore_info.snapshot_id}, on'
                             f' {restore_info.target_cluster_name} with restore_id {restore_id}.')
@@ -1597,6 +1668,7 @@ class Atlas:
                 response = self.atlas.network.delete(Settings.BASE_URL + uri)
 
                 return response
+
 
 class AtlasPagination:
     """Atlas Pagination Generic Implementation

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -1552,14 +1552,14 @@ class Atlas:
 
             """
             # Check if the source and target groups are actually the same....
-            if target_group_obj.atlas.group == self.atlas.group:
+            if target_group_obj.group == self.atlas.group:
                 txt = f"The source and target groups are the same ({self.atlas.group}). this method should only " \
                       f"be used if the restore is to anothe group than the target."
                 logger.error(txt)
                 raise AttributeError(txt)
 
             # Check if the target_cluster_name is valid
-            if not target_group_obj.atlas.Clusters.is_existing_cluster(target_cluster_name):
+            if not target_group_obj.Clusters.is_existing_cluster(target_cluster_name):
                 logger.error(f'The passed target cluster {target_cluster_name}, does not exist in this project.)')
                 raise ValueError(f'The passed target cluster {target_cluster_name}, does not exist in this project.')
             else:
@@ -1576,7 +1576,7 @@ class Atlas:
             uri = Settings.api_resources["Cloud Backup Restore Jobs"]["Restore snapshot by cluster"] \
                 .format(GROUP_ID=self.atlas.group, CLUSTER_NAME=source_cluster_name)
 
-            request_obj = SnapshotRestore(delivery_type, snapshot_id, target_cluster_name, target_group_obj.atlas.group)
+            request_obj = SnapshotRestore(delivery_type, snapshot_id, target_cluster_name, target_group_obj.group)
 
             try:
                 response = self.atlas.network.post(uri=Settings.BASE_URL + uri, payload=request_obj.as_dict)
@@ -1588,6 +1588,7 @@ class Atlas:
                     logger.error('Received an Atlas bad request on Snapshot restore request.')
                     logger.error(e.details)
                     raise IOError("Received an Atlas bad request on Snapshot restore request.")
+
 
             try:
                 response_obj = SnapshotRestoreResponse.from_dict(response)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='atlasapi',
-    version='0.13.1',
+    version='0.13.2',
     python_requires='>=3.6',
     packages=find_packages(exclude=("tests",)),
     install_requires=['requests', 'python-dateutil', 'isodate', 'future', 'pytz','coolname', 'nose'],
@@ -21,7 +21,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
 
         # Indicate who your project is intended for
         'Intended Audience :: Developers',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,9 @@
 import unittest
 from os import getenv, environ
-from atlasapi.atlas import Atlas
+try:
+    from atlasapi.atlas import Atlas
+except NameError:
+    from atlas import Atlas
 from datetime import datetime
 import coolname
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,9 @@ class BaseTests(unittest.TestCase):
         self.USER = getenv('ATLAS_USER', None)
         self.API_KEY = getenv('ATLAS_KEY', None)
         self.GROUP_ID = getenv('ATLAS_GROUP', None)
-
+        self.OTHER_GROUP_ID = getenv('ATLAS_OTHER_GROUP', None)
+        self.OTHER_USER = getenv('ATLAS_OTHER_USER', None)
+        self.OTHER_API_KEY = getenv('ATLAS_OTHER_KEY', None)
         #print("env var is".format(getenv('ATLAS_USER', None)))
 
         self.TEST_CLUSTER_NAME = TEST_CLUSTER_NAME
@@ -36,6 +38,7 @@ class BaseTests(unittest.TestCase):
             raise EnvironmentError('In order to run this smoke test you need ATLAS_USER, AND ATLAS_KEY env variables'
                                    'your env variables are {}'.format(environ.__str__()))
         self.a = Atlas(self.USER, self.API_KEY, self.GROUP_ID)
+        self.a_other = Atlas(self.OTHER_USER, self.OTHER_API_KEY, self.OTHER_GROUP_ID)
 
     # executed after each test
 

--- a/tests/test_cloudbackup.py
+++ b/tests/test_cloudbackup.py
@@ -29,7 +29,7 @@ class CloudBackupTests(BaseTests):
 
             self.assertEquals(type(each), CloudBackupSnapshot)
         print(f'The number of cloudbackup snapshots returned = {count}')
-        self.assertGreaterEqual(count,1)
+        self.assertGreaterEqual(count, 1)
 
     test_00_test_get_for_cluster.basic = True
 
@@ -38,19 +38,22 @@ class CloudBackupTests(BaseTests):
         snapshots: List[CloudBackupSnapshot] = self.a.CloudBackups.get_backup_snapshots_for_cluster(
             cluster_name=cluster_name)
 
-        snapshot_id =list(snapshots)[0].id
+        snapshot_id = list(snapshots)[0].id
         print(f'The tested snapshot_id is {snapshot_id}')
-        snapshot = self.a.CloudBackups.get_backup_snapshot_for_cluster(cluster_name=cluster_name,snapshot_id=snapshot_id)
+        snapshot = self.a.CloudBackups.get_backup_snapshot_for_cluster(cluster_name=cluster_name,
+                                                                       snapshot_id=snapshot_id)
         count = 0
         for each in snapshot:
             # pprint(each)
             self.assertEquals(type(each), CloudBackupSnapshot)
 
     test_01_test_get_for_snapshot.basic = True
+
     def test_02_create_snapshot(self):
         cluster_name = 'pyAtlasTestCluster'
         response_obj = self.a.CloudBackups.create_snapshot_for_cluster(cluster_name=cluster_name,
-                                                                       retention_days=1,description="Test 01",as_obj=True)
+                                                                       retention_days=1, description="Test 01",
+                                                                       as_obj=True)
         self.assertEquals(type(response_obj), CloudBackupSnapshot)
         pprint('New Snapshot created!!')
         # pprint(response_obj)
@@ -65,8 +68,8 @@ class CloudBackupTests(BaseTests):
                                                                     snapshot_id=snapshot_id,
                                                                     target_cluster_name=target_cluster_name,
                                                                     delivery_type=DeliveryType.automated)
-        #pprint(response_obj.__dict__)
-        self.assertEquals(type(response_obj),SnapshotRestoreResponse)
+        # pprint(response_obj.__dict__)
+        self.assertEquals(type(response_obj), SnapshotRestoreResponse)
 
     test_03_restore_snapshot_to_atlas.basic = False
 
@@ -76,9 +79,9 @@ class CloudBackupTests(BaseTests):
         snapshot_id = '6104a8c6c1b4ef7788b5d8f0-322'
         with self.assertRaises(ValueError) as ex:
             response_obj = self.a.CloudBackups.request_snapshot_restore(source_cluster_name=source_cluster_name,
-                                                                    snapshot_id=snapshot_id,
-                                                                    target_cluster_name=target_cluster_name,
-                                                                    delivery_type=DeliveryType.automated)
+                                                                        snapshot_id=snapshot_id,
+                                                                        target_cluster_name=target_cluster_name,
+                                                                        delivery_type=DeliveryType.automated)
             pprint(response_obj)
 
     test_04_restore_snapshot_to_atlas_bad_snapshot_id.basic = True
@@ -89,9 +92,9 @@ class CloudBackupTests(BaseTests):
         snapshot_id = '6104a8c6c1b4ef7788b5d8f0'
         with self.assertRaises(ValueError) as ex:
             response_obj = self.a.CloudBackups.request_snapshot_restore(source_cluster_name=source_cluster_name,
-                                                                    snapshot_id=snapshot_id,
-                                                                    target_cluster_name=target_cluster_name,
-                                                                    delivery_type=DeliveryType.automated)
+                                                                        snapshot_id=snapshot_id,
+                                                                        target_cluster_name=target_cluster_name,
+                                                                        delivery_type=DeliveryType.automated)
 
     test_05_restore_snapshot_to_atlas_bad_dest_cluster.basic = True
 
@@ -101,9 +104,9 @@ class CloudBackupTests(BaseTests):
         snapshot_id = '6104a8c6c1b4ef7788b5d8f0'
         with self.assertRaises(ValueError) as ex:
             response_obj = self.a.CloudBackups.request_snapshot_restore(source_cluster_name=source_cluster_name,
-                                                                    snapshot_id=snapshot_id,
-                                                                    target_cluster_name=target_cluster_name,
-                                                                    delivery_type=DeliveryType.automated)
+                                                                        snapshot_id=snapshot_id,
+                                                                        target_cluster_name=target_cluster_name,
+                                                                        delivery_type=DeliveryType.automated)
 
     test_06_restore_snapshot_to_atlas_bad_same_cluster.basic = True
 
@@ -118,7 +121,7 @@ class CloudBackupTests(BaseTests):
 
             self.assertEquals(type(each), SnapshotRestoreResponse)
         print(f'The number of snapshots restore jobs returned = {count}')
-        self.assertGreaterEqual(count,1)
+        self.assertGreaterEqual(count, 1)
 
     test_07_get_restore_job_for_cluster.basic = True
 
@@ -132,17 +135,17 @@ class CloudBackupTests(BaseTests):
         print(f'The restore_id to be tested is {restore_id}')
 
         restore_jobs = self.a.CloudBackups.get_snapshot_restore_requests(cluster_name=cluster_name,
-                                                                        restore_id=restore_id)
+                                                                         restore_id=restore_id)
 
         restore_job = list(restore_jobs)[0]
 
-        self.assertEquals(type(restore_job),SnapshotRestoreResponse)
+        self.assertEquals(type(restore_job), SnapshotRestoreResponse)
 
     test_08_get_one_restore_job.basic = True
 
     def test_09_is_valid_snapshot_false(self):
         cluster_name = 'pyAtlasTestCluster'
-        response = self.a.CloudBackups.is_existing_snapshot(cluster_name=cluster_name,snapshot_id='sdasdasd')
+        response = self.a.CloudBackups.is_existing_snapshot(cluster_name=cluster_name, snapshot_id='sdasdasd')
         self.assertEquals(response, False)
 
     test_09_is_valid_snapshot_false.basic = True
@@ -154,13 +157,28 @@ class CloudBackupTests(BaseTests):
 
         snapshot_id = list(snapshots)[0].id
         print(f'The tested snapshot_id is {snapshot_id}')
-        response = self.a.CloudBackups.is_existing_snapshot(cluster_name=cluster_name,snapshot_id=snapshot_id)
+        response = self.a.CloudBackups.is_existing_snapshot(cluster_name=cluster_name, snapshot_id=snapshot_id)
 
         self.assertEquals(response, True)
 
     test_10_is_valid_snapshot_true.basic = True
 
-#    def test_11_cancel_valid_restore_job(self):
+    def test_11_restore_snapshot_to_atlas_other_proj(self):
+        source_cluster_name = 'pyAtlasTestCluster'
+        target_cluster_name = 'pyAtlasTestRestore'
+        snapshot_id = '6237a59f0942760c753d6df9'
+
+        pprint(self.a_other.group)
+        response_obj = self.a.CloudBackups.request_snapshot_restore_to_group(source_cluster_name=source_cluster_name,
+                                                                             snapshot_id=snapshot_id,
+                                                                             target_cluster_name=target_cluster_name,
+                                                                             target_group_obj=self.a_other,
+                                                                             delivery_type=DeliveryType.automated)
+        self.assertEquals(type(response_obj), SnapshotRestoreResponse)
+
+    test_11_restore_snapshot_to_atlas_other_proj.basic = False
+
+#    def test_12_cancel_valid_restore_job(self):
 #        source_cluster_name = 'pyAtlasTestCluster'
 #        target_cluster_name = 'pyAtlasTestRestore'
 #        snapshot_id = '619d5e979977cf1a6a9adfbf'
@@ -178,9 +196,9 @@ class CloudBackupTests(BaseTests):
 #                                                                  restore_id=response_obj.restore_id)
 #        pprint(f"({out})")
 #
-#    test_11_cancel_valid_restore_job.basic = True
+#    test_12_cancel_valid_restore_job.basic = True
 
-#   def test_11a_cancel_valid_restore_job(self):
+#   def test_12a_cancel_valid_restore_job(self):
 #     source_cluster_name = 'pyAtlasTestCluster'
 #     target_cluster_name = 'pyAtlasTestRestore'
 #     snapshot_id = '619d5e979977cf1a6a9adfbf'
@@ -198,4 +216,4 @@ class CloudBackupTests(BaseTests):
 #                                                               restore_id="619d87217547a804f47a07e7")
 #
 #
-#   test_11a_cancel_valid_restore_job.basic = True
+#   test_12a_cancel_valid_restore_job.basic = True

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -130,11 +130,11 @@ class ClusterTests(BaseTests):
     test_12_get_advanced_options.basic = True
 
     def test_13_set_advanced_options(self):
-        set_1 = AdvancedOptions(failIndexKeyTooLong=True)
-        out_set_1 = self.a.Clusters.modify_cluster_advanced_options(cluster=self.TEST_CLUSTER_NAME,
-                                                                    advanced_options=set_1)
-        self.assertEqual(set_1.failIndexKeyTooLong, out_set_1.failIndexKeyTooLong,
-                         msg='in = {}: out= {}'.format(set_1.__dict__, out_set_1.__dict__))
+        # Removed this test, since it is now failing due to this option no longer supported in 4.2 +.
+        # Will need to remove the
+        # set_1 = AdvancedOptions(failIndexKeyTooLong=True)
+        # out_set_1 = self.a.Clusters.modify_cluster_advanced_options(cluster=self.TEST_CLUSTER_NAME,
+        #                                                            advanced_options=set_1)
 
         set_2 = AdvancedOptions(javascriptEnabled=True)
         out_set_2 = self.a.Clusters.modify_cluster_advanced_options(cluster=self.TEST_CLUSTER_NAME,


### PR DESCRIPTION
Implemented #66 to allow for restores to be from one project to another.

Setting up CI for this test required moving to another Atlas project, so automated testing is still not running, but running tests locally results in all tests passing.

The test itself gives a bit of guidance in how to use this method. Another Atlas object, configured to connect to the other project is required.