### PR TITLE
Fixing documentation for methods whose names have changed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,13 +151,13 @@ Clusters
         print(cluster["name"])
     
     # Get a Single Cluster
-    details = a.Clusters.get_a_single_cluster("cluster-dev")
+    details = a.Clusters.get_single_cluster("cluster-dev")
     
     # Delete a Cluster (dry run, raise ErrConfirmationRequested)
-    details = a.Clusters.delete_a_cluster("cluster-dev")
+    details = a.Clusters.delete_cluster("cluster-dev")
     
     # Delete a Cluster (approved)
-    details = a.Clusters.delete_a_cluster("cluster-dev", areYouSure=True)
+    details = a.Clusters.delete_cluster("cluster-dev", areYouSure=True)
 
     # Create a Simple Replica Set Cluster
 
@@ -173,14 +173,14 @@ Clusters
                                providerSettings=provider_settings,
                                replication_specs=replication_specs)
 
-    output = a.Clusters.create_a_cluster(cluster_config)
+    output = a.Clusters.create_cluster(cluster_config)
 
 
     # Modify a cluster
-    existing_config = a.Clusters.get_a_single_cluster_as_obj(cluster=TEST_CLUSTER_NAME)
+    existing_config = a.Clusters.get_single_cluster_as_obj(cluster=TEST_CLUSTER_NAME)
     out.providerSettings.instance_size_name = InstanceSizeName.M10
     out.disk_size_gb = 13
-    new_config = a.Clusters.modify_a_cluster('pyAtlasAPIClustersTest', out)
+    new_config = a.Clusters.modify_cluster('pyAtlasAPIClustersTest', out)
     pprint(new_config)
 
     # Modify cluster instance size

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -266,7 +266,7 @@ class Atlas:
                 return self.atlas.network.delete(Settings.BASE_URL + uri)
             else:
                 raise ErrConfirmationRequested(
-                    "Please set areYouSure=True on delete_a_cluster call if you really want to delete [%s]" % cluster)
+                    "Please set areYouSure=True on delete_cluster call if you really want to delete [%s]" % cluster)
 
         def modify_cluster(self, cluster: str, cluster_config: Union[ClusterConfig, dict]) -> dict:
             """Modify a Cluster

--- a/doc_corrections.diff
+++ b/doc_corrections.diff
@@ -1,0 +1,82 @@
+diff --git a/README.rst b/README.rst
+index 8ffb7ce..02acb8a 100644
+--- a/README.rst
++++ b/README.rst
+@@ -151,13 +151,13 @@ Clusters
+         print(cluster["name"])
+     
+     # Get a Single Cluster
+-    details = a.Clusters.get_a_single_cluster("cluster-dev")
++    details = a.Clusters.get_single_cluster("cluster-dev")
+     
+     # Delete a Cluster (dry run, raise ErrConfirmationRequested)
+-    details = a.Clusters.delete_a_cluster("cluster-dev")
++    details = a.Clusters.delete_cluster("cluster-dev")
+     
+     # Delete a Cluster (approved)
+-    details = a.Clusters.delete_a_cluster("cluster-dev", areYouSure=True)
++    details = a.Clusters.delete_cluster("cluster-dev", areYouSure=True)
+ 
+     # Create a Simple Replica Set Cluster
+ 
+@@ -173,14 +173,14 @@ Clusters
+                                providerSettings=provider_settings,
+                                replication_specs=replication_specs)
+ 
+-    output = a.Clusters.create_a_cluster(cluster_config)
++    output = a.Clusters.create_cluster(cluster_config)
+ 
+ 
+     # Modify a cluster
+-    existing_config = a.Clusters.get_a_single_cluster_as_obj(cluster=TEST_CLUSTER_NAME)
++    existing_config = a.Clusters.get_single_cluster_as_obj(cluster=TEST_CLUSTER_NAME)
+     out.providerSettings.instance_size_name = InstanceSizeName.M10
+     out.disk_size_gb = 13
+-    new_config = a.Clusters.modify_a_cluster('pyAtlasAPIClustersTest', out)
++    new_config = a.Clusters.modify_cluster('pyAtlasAPIClustersTest', out)
+     pprint(new_config)
+ 
+     # Modify cluster instance size
+diff --git a/atlasapi/atlas.py b/atlasapi/atlas.py
+index 591cbff..77c7686 100644
+--- a/atlasapi/atlas.py
++++ b/atlasapi/atlas.py
+@@ -267,7 +267,7 @@ class Atlas:
+                 return self.atlas.network.delete(Settings.BASE_URL + uri)
+             else:
+                 raise ErrConfirmationRequested(
+-                    "Please set areYouSure=True on delete_a_cluster call if you really want to delete [%s]" % cluster)
++                    "Please set areYouSure=True on delete_cluster call if you really want to delete [%s]" % cluster)
+ 
+         def modify_cluster(self, cluster: str, cluster_config: Union[ClusterConfig, dict]) -> dict:
+             """Modify a Cluster
+diff --git a/tests/test_clusters.py b/tests/test_clusters.py
+index 93fb341..c0e3755 100644
+--- a/tests/test_clusters.py
++++ b/tests/test_clusters.py
+@@ -73,13 +73,13 @@ class ClusterTests(BaseTests):
+         sleep(20)
+         print('-----------------------------------Done Sleeping -------------------------------------')
+ 
+-    def test_06_delete_a_cluster(self):
++    def test_06_delete_cluster(self):
+         myoutput = self.a.Clusters.delete_cluster(cluster=self.TEST_CLUSTER2_NAME_UNIQUE, areYouSure=True)
+         print('Successfully Deleted {}, output was '.format(self.TEST_CLUSTER2_NAME_UNIQUE, myoutput))
+ 
+-    test_06_delete_a_cluster.advanced = True
++    test_06_delete_cluster.advanced = True
+ 
+-    def test_07_create_a_cluster(self):
++    def test_07_create_cluster(self):
+         provider_settings: ProviderSettings = ProviderSettings()
+         regions_config = RegionConfig()
+         replication_specs = ReplicationSpecs(regions_config={provider_settings.region_name: regions_config.__dict__})
+@@ -90,7 +90,7 @@ class ClusterTests(BaseTests):
+         output = self.a.Clusters.create_cluster(cluster_config)
+         pprint(output)
+ 
+-    test_07_create_a_cluster.advanced = True
++    test_07_create_cluster.advanced = True
+ 
+     def test_08_resize_a_cluster(self):
+         self.a.Clusters.modify_cluster_instance_size(cluster=self.TEST_CLUSTER3_NAME_UNIQUE,

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -73,13 +73,13 @@ class ClusterTests(BaseTests):
         sleep(20)
         print('-----------------------------------Done Sleeping -------------------------------------')
 
-    def test_06_delete_a_cluster(self):
+    def test_06_delete_cluster(self):
         myoutput = self.a.Clusters.delete_cluster(cluster=self.TEST_CLUSTER2_NAME_UNIQUE, areYouSure=True)
         print('Successfully Deleted {}, output was '.format(self.TEST_CLUSTER2_NAME_UNIQUE, myoutput))
 
-    test_06_delete_a_cluster.advanced = True
+    test_06_delete_cluster.advanced = True
 
-    def test_07_create_a_cluster(self):
+    def test_07_create_cluster(self):
         provider_settings: ProviderSettings = ProviderSettings()
         regions_config = RegionConfig()
         replication_specs = ReplicationSpecs(regions_config={provider_settings.region_name: regions_config.__dict__})
@@ -90,7 +90,7 @@ class ClusterTests(BaseTests):
         output = self.a.Clusters.create_cluster(cluster_config)
         pprint(output)
 
-    test_07_create_a_cluster.advanced = True
+    test_07_create_cluster.advanced = True
 
     def test_08_resize_a_cluster(self):
         self.a.Clusters.modify_cluster_instance_size(cluster=self.TEST_CLUSTER3_NAME_UNIQUE,


### PR DESCRIPTION
I just started using this package and noticed some documentation is slightly off. It seems some '_a_'s got removed from method names. Ex: 'get_a_single_cluster' appears to now be named 'get_single_cluster'

Thanks for writing this repo, btw. It's been very useful for my devops gig.