### PR TITLE
104 clustername in hosts object is parsing by breaks when name includes a

### DIFF
--- a/atlasapi/__init__.py
+++ b/atlasapi/__init__.py
@@ -15,4 +15,4 @@
 # __init__.py
 
 # Version of the realpython-reader package
-__version__ = "1.1.5"
+__version__ = "1.1.6"

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -478,6 +478,7 @@ class Atlas:
                 obj_list = list()
                 for item in item_list:
                     obj_list.append(Host(item))
+
                 return_val = obj_list
             else:
                 uri = Settings.api_resources["Monitoring and Logs"]["Get all processes for group"].format(
@@ -507,6 +508,8 @@ class Atlas:
                 out_list = list()
                 for host in host_list:
                     if host.cluster_name.lower() == for_cluster.lower():
+                        out_list.append(host)
+                    elif host.cluster_name_alias.lower() == for_cluster.lower():
                         out_list.append(host)
                 self.host_list = out_list
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='atlasapi',
-    version='1.1.5',
+    version='1.1.6',
     python_requires='>=3.7',
     packages=find_packages(exclude=("tests",)),
     install_requires=['requests', 'python-dateutil', 'isodate', 'future', 'pytz','coolname', 'humanfriendly', 'nose'],

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -161,3 +161,7 @@ class ClusterTests(BaseTests):
                          msg='in = {}: out= {}'.format(set_5.__dict__, out_set_5.__dict__))
 
     test_13_set_advanced_options.basic = True
+
+
+
+

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 logger = logging.getLogger('test')
 
 
+# noinspection PyTypeChecker
 class MeasurementTests(BaseTests):
 
     def test_00_get_hosts_count(self):
@@ -257,7 +258,8 @@ class MeasurementTests(BaseTests):
         self.a.Hosts.fill_host_list()
         for each_host in self.a.Hosts.host_list_secondaries:
             print(
-                f'Cluster: {each_host.cluster_name}, Host: {each_host.hostname}, is type: {each_host.type} ia port {each_host.port}')
+                f'Cluster: {each_host.cluster_name}, Host: {each_host.hostname}, is type'
+                f': {each_host.type} ia port {each_host.port}')
             self.assertEqual(each_host.type, ReplicaSetTypes.REPLICA_SECONDARY)
             measurements = list(
                 each_host.get_measurement_for_host(atlas_obj=self.a, measurement=AtlasMeasurementTypes.Db.data_size))
@@ -269,6 +271,21 @@ class MeasurementTests(BaseTests):
         self.a.Hosts.fill_host_list(for_cluster='monkeypants')
         self.assertEqual(len(list(self.a.Hosts.host_list)), 0)
 
+    test_18_return_no_hosts_if_wrong_filter.basic = True
+
     def test_19_issue101_case_insensitive_clustername(self):
         self.a.Hosts.fill_host_list(for_cluster='pyAtlasTestCluster')
         self.assertGreater(len(list(self.a.Hosts.host_list)), 1)
+
+    test_19_issue101_case_insensitive_clustername.basic = True
+
+    def test_20_issue_104_hyphen_in_cluster_name(self):
+        cluster_name = 'cluster-02'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+        for each in self.a.Hosts.host_list:
+            print(
+                f'cluster: {each.cluster_name} - Host: {each.hostname_alias}'
+                f' cluster_name_alias= {each.cluster_name_alias}')
+            self.assertEqual(cluster_name, each.cluster_name_alias)
+
+    test_20_issue_104_hyphen_in_cluster_name.basic = False


### PR DESCRIPTION
Resolves #104 

Also contains some refactoring discovered when investigating this problem.

In general there is no direct link between a cluster (database deployment) and a host (instance) we can only infer from the hostnames (both the generated hostname as well as the user alias hostname.  Added some ifthen logic to try both the hostname and the hostname alias to work around as much as possible.

The remaining open issues is that if anything other than lowercase is used for clusternames, one can not infer the clustername from the hostnames. This is currently not fixable, as far as I can see.