### PR TITLE
92 support for database level metrics and 100 support for disk metrics.

### DIFF
--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -24,7 +24,8 @@ from atlasapi.errors import *
 from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 from atlasapi.specs import Host, ListOfHosts, DatabaseUsersUpdatePermissionsSpecs, DatabaseUsersPermissionsSpecs, \
-    OptionalAtlasMeasurement, AtlasMeasurement, AtlasMeasurementValue, AtlasMeasurementTypes, ReplicaSetTypes
+    ReplicaSetTypes
+from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement, OptionalAtlasMeasurement
 from typing import Union, Iterator, List, Optional
 from atlasapi.atlas_types import OptionalInt, OptionalBool, ListofDict
 from atlasapi.clusters import ClusterConfig, ShardedClusterConfig, AtlasBasicReplicaSet, \
@@ -606,10 +607,10 @@ class Atlas:
 
 
                             :param return_data:
-                            :rtype: List[specs.AtlasMeasurement]
+                            :rtype: List[measurements.AtlasMeasurement]
                             :type period: AtlasPeriods
                             :type granularity: AtlasGranularities
-                            :type measurement: specs.AtlasMeasurementTypes
+                            :type measurement: measurements.AtlasMeasurementTypes
                         """
 
             if not self.host_list:
@@ -801,14 +802,14 @@ class Atlas:
             Raises:
                 ErrPaginationLimits: Out of limits
 
-                :rtype: List[specs.AtlasMeasurement]
+                :rtype: List[measurements.AtlasMeasurement]
                 :type iterable: OptionalBool
                 :type itemsPerPage: OptionalInt
                 :type pageNum: OptionalInt
                 :type period: AtlasPeriods
                 :type granularity: AtlasGranularities
                 :type host_obj: Host
-                :type measurement: specs.AtlasMeasurementTypes
+                :type measurement: measurements.AtlasMeasurementTypes
 
             """
 

--- a/atlasapi/atlas.py
+++ b/atlasapi/atlas.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 from atlasapi.specs import Host, ListOfHosts, DatabaseUsersUpdatePermissionsSpecs, DatabaseUsersPermissionsSpecs, \
     ReplicaSetTypes
-from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement, OptionalAtlasMeasurement
+from atlasapi.measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement, OptionalAtlasMeasurement
 from typing import Union, Iterator, List, Optional
 from atlasapi.atlas_types import OptionalInt, OptionalBool, ListofDict
 from atlasapi.clusters import ClusterConfig, ShardedClusterConfig, AtlasBasicReplicaSet, \

--- a/atlasapi/clusters.py
+++ b/atlasapi/clusters.py
@@ -263,7 +263,7 @@ class ClusterConfig(object):
                  cluster_type: ClusterType = ClusterType.REPLICASET,
                  disk_size_gb: int = 32,
                  name: str = None,
-                 mongodb_major_version: MongoDBMajorVersion = MongoDBMajorVersion.v4_0,
+                 mongodb_major_version: MongoDBMajorVersion = MongoDBMajorVersion.v4_4,
                  mongodb_version: Optional[str] = None,
                  num_shards: int = 1,
                  mongo_uri: Optional[str] = None,

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -185,7 +185,37 @@ class AtlasMeasurementTypes(_GetAll):
             guest = 'SYSTEM_NORMALIZED_CPU_GUEST'
             steal = 'SYSTEM_NORMALIZED_CPU_STEAL'
 
+    class Disk(_GetAll):
+        class IOPS(_GetAll):
+            read = 'DISK_PARTITION_IOPS_READ'
+            read_max = 'MAX_DISK_PARTITION_IOPS_READ'
+            write = 'DISK_PARTITION_IOPS_WRITE'
+            write_max = 'MAX_DISK_PARTITION_IOPS_WRITE'
+            total = 'DISK_PARTITION_IOPS_TOTAL'
+            total_max = 'MAX_DISK_PARTITION_IOPS_TOTAL'
 
+        class Util(_GetAll):
+            util = 'DISK_PARTITION_UTILIZATION'
+            util_max = 'MAX_DISK_PARTITION_UTILIZATION'
+
+        class Latency(_GetAll):
+            read = 'DISK_PARTITION_LATENCY_READ'
+            read_max = 'MAX_DISK_PARTITION_LATENCY_READ'
+            write = 'DISK_PARTITION_LATENCY_WRITE'
+            write_max = 'MAX_DISK_PARTITION_LATENCY_WRITE'
+
+        class Free(_GetAll):
+            space_free = 'DISK_PARTITION_SPACE_FREE'
+            space_free_max = 'MAX_DISK_PARTITION_SPACE_FREE'
+            used = 'DISK_PARTITION_SPACE_USED'
+            used_max = 'MAX_DISK_PARTITION_SPACE_USED'
+            percent_fee = 'DISK_PARTITION_SPACE_PERCENT_FREE'
+            percent_free_max = 'MAX_DISK_PARTITION_SPACE_PERCENT_FREE'
+            percent_used = 'DISK_PARTITION_SPACE_PERCENT_USED'
+            percent_used_max = 'MAX_DISK_PARTITION_SPACE_PERCENT_USED'
+
+
+# noinspection PyBroadException
 class AtlasMeasurementValue(object):
     def __init__(self, value_dict: dict):
         """
@@ -328,7 +358,7 @@ class AtlasMeasurement(object):
             dict:
         """
         return dict(measurements=self._measurements, date_start=self.date_start, date_end=self.date_end, name=self.name,
-                    units= self.units, period=self.period, granularity=self.granularity,
+                    units=self.units, period=self.period, granularity=self.granularity,
                     measurements_count=self.measurements_count
                     )
 
@@ -346,9 +376,7 @@ class AtlasMeasurement(object):
         data_list = list()
         for each_measurement in self.measurements:
             data_list.append(each_measurement.value_float)
-        return StatisticalValuesFriendly(data_list=data_list,data_type=self.units)
-
-
+        return StatisticalValuesFriendly(data_list=data_list, data_type=self.units)
 
     def __hash__(self):
         return hash(self.name + '-' + self.period)
@@ -360,7 +388,7 @@ class AtlasMeasurement(object):
         :return:
         """
         if isinstance(other, AtlasMeasurement):
-            return ((self.name == other.name) and (self.period == other.period))
+            return (self.name == other.name) and (self.period == other.period)
 
 
 ListOfAtlasMeasurementValues = NewType('ListOfAtlasMeasurementValues', List[Optional[AtlasMeasurementValue]])

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -7,8 +7,8 @@ import logging
 import humanfriendly as hf
 from dateutil.parser import parse
 
-from atlas_types import OptionalFloat
-from lib import _GetAll, AtlasPeriods, AtlasGranularities
+from atlasapi.atlas_types import OptionalFloat
+from atlasapi.lib import _GetAll, AtlasPeriods, AtlasGranularities
 
 logger: logging.Logger = logging.getLogger('Atlas.measurements')
 

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -214,6 +214,21 @@ class AtlasMeasurementTypes(_GetAll):
             percent_used = 'DISK_PARTITION_SPACE_PERCENT_USED'
             percent_used_max = 'MAX_DISK_PARTITION_SPACE_PERCENT_USED'
 
+    class Namespaces(_GetAll):
+        """Metrics regarding namespaces (databases) on each host.
+
+        As found in dbstats (https://www.mongodb.com/docs/manual/reference/command/dbStats/)
+            """
+        object_size = 'DATABASE_AVERAGE_OBJECT_SIZE' # dbStats.avgObjSize Average size of each document in bytes. This is the dataSize divided by the number of documents. The scale argument does not affect the avgObjSize value.
+        collection_count = 'DATABASE_COLLECTION_COUNT'
+        data_size = 'DATABASE_DATA_SIZE' # Total size of the uncompressed data held in the database. The dataSize decreases when you remove documents.
+        storage_size = 'DATABASE_STORAGE_SIZE' # Sum of the space allocated to all collections in the database for document storage, including free space. storageSize does not include space allocated to indexes. See indexSize for the total index size.
+        index_size = 'DATABASE_INDEX_SIZE' # Sum of the space allocated to all indexes in the database, including free index space.
+        index_count = 'DATABASE_INDEX_COUNT'
+        extent_count = 'DATABASE_EXTENT_COUNT' # ?
+        object_count = 'DATABASE_OBJECT_COUNT' # Number of objects (specifically, documents) in the database across all collections.
+        view_count = 'DATABASE_VIEW_COUNT'
+
 
 # noinspection PyBroadException
 class AtlasMeasurementValue(object):

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -1,0 +1,377 @@
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+from datetime import datetime
+from statistics import mean, StatisticsError
+from typing import Optional, Tuple, List, Iterable, NewType
+import logging
+import humanfriendly as hf
+from dateutil.parser import parse
+
+from atlas_types import OptionalFloat
+from lib import _GetAll, AtlasPeriods, AtlasGranularities
+
+logger: logging.Logger = logging.getLogger('Atlas.measurements')
+
+
+class StatisticalValues:
+    def __init__(self, data_list: list):
+        try:
+            self.samples: int = len(clean_list(data_list))
+            self.mean: float = float(mean(clean_list(data_list)))
+            self.min: float = float(min(clean_list(data_list)))
+            self.max: float = float(max(clean_list(data_list)))
+        except StatisticsError:
+            logger.warning('Could not compute statistical values.')
+            self.samples: int = 0
+            self.mean: int = 0
+            self.min: float = 0
+            self.max: float = 0
+
+
+class StatisticalValuesFriendly:
+    def __init__(self, data_list: list, data_type: str = None) -> None:
+        """Returns human-readable values for stats
+
+        Args:
+            data_list:
+            data_type: The datatype either bytes or number
+        """
+        try:
+            if data_type is None:
+                data_type = 'bytes'
+            if data_type == 'bytes':
+                self.mean: str = hf.format_size(mean(clean_list(data_list)))
+                self.min: str = hf.format_size(min(clean_list(data_list)))
+                self.max: str = hf.format_size(max(clean_list(data_list)))
+            else:
+                self.mean: str = hf.format_number(mean(clean_list(data_list)))
+                self.min: str = hf.format_number(min(clean_list(data_list)))
+                self.max: str = hf.format_number(max(clean_list(data_list)))
+        except StatisticsError:
+            logger.warning('Could not compute statistical values.')
+            self.mean: str = 'No Value'
+            self.min: str = 'No value'
+            self.max: str = 'No value'
+
+
+class AtlasMeasurementTypes(_GetAll):
+    """
+    Helper class for all available atlas measurements.
+
+    All classes and embedded classes have a get_all class method that returns an iterator of all measurements
+    and sub measurements.
+
+    """
+    connections = 'CONNECTIONS'
+
+    class Asserts(_GetAll):
+        regular = 'ASSERT_REGULAR'
+        warning = 'ASSERT_WARNING'
+        msg = 'ASSERT_MSG'
+        user = 'ASSERT_USER'
+
+    class Cache(_GetAll):
+        bytes_read = 'CACHE_BYTES_READ_INTO'
+        bytes_written = 'CACHE_BYTES_WRITTEN_FROM'
+        dirty = 'CACHE_DIRTY_BYTES'
+        used = 'CACHE_USED_BYTES'
+
+    class Cursors(_GetAll):
+        open = 'CURSORS_TOTAL_OPEN'
+        timed_out = 'CURSORS_TOTAL_TIMED_OUT'
+
+    class Db(_GetAll):
+        storage = 'DB_STORAGE_TOTAL'
+        data_size = 'DB_DATA_SIZE_TOTAL'
+
+    class DocumentMetrics(_GetAll):
+        returned = 'DOCUMENT_METRICS_RETURNED'
+        inserted = 'DOCUMENT_METRICS_INSERTED'
+        updated = 'DOCUMENT_METRICS_UPDATED'
+        deleted = 'DOCUMENT_METRICS_DELETED'
+
+    class ExtraInfo(_GetAll):
+        page_faults = 'EXTRA_INFO_PAGE_FAULTS'
+
+    class GlobalLockCurrentQueue(_GetAll):
+        total = 'GLOBAL_LOCK_CURRENT_QUEUE_TOTAL'
+        readers = 'GLOBAL_LOCK_CURRENT_QUEUE_READERS'
+        writers = 'GLOBAL_LOCK_CURRENT_QUEUE_WRITERS'
+
+    class Memory(_GetAll):
+        resident = 'MEMORY_RESIDENT'
+        virtual = 'MEMORY_VIRTUAL'
+        mapped = 'MEMORY_MAPPED'
+
+    class Network(_GetAll):
+        bytes_id = 'NETWORK_BYTES_IN'  # initial typo, kept for backwards compatibility
+        bytes_in = 'NETWORK_BYTES_IN'
+        bytes_out = 'NETWORK_BYTES_OUT'
+        num_requests = 'NETWORK_NUM_REQUESTS'
+
+    class Opcounter(_GetAll):
+        cmd = 'OPCOUNTER_CMD'
+        query = 'OPCOUNTER_QUERY'
+        update = 'OPCOUNTER_UPDATE'
+        delete = 'OPCOUNTER_DELETE'
+        getmore = 'OPCOUNTER_GETMORE'
+        insert = 'OPCOUNTER_INSERT'
+
+        class Repl(_GetAll):
+            cmd = 'OPCOUNTER_REPL_CMD'
+            update = 'OPCOUNTER_REPL_UPDATE'
+            delete = 'OPCOUNTER_REPL_DELETE'
+            insert = 'OPCOUNTER_REPL_INSERT'
+
+    class Operations(_GetAll):
+        scan_and_order = 'OPERATIONS_SCAN_AND_ORDER'
+
+        class ExecutionTime(_GetAll):
+            reads = 'OP_EXECUTION_TIME_READS'
+            writes = 'OP_EXECUTION_TIME_WRITES'
+            commands = 'OP_EXECUTION_TIME_COMMANDS'
+
+    class Oplog(_GetAll):
+        master_time = 'OPLOG_MASTER_TIME'
+        rate = 'OPLOG_RATE_GB_PER_HOUR'
+
+    class QueryExecutor(_GetAll):
+        scanned = 'QUERY_EXECUTOR_SCANNED'
+        scanned_objects = 'QUERY_EXECUTOR_SCANNED_OBJECTS'
+
+    class QueryTargetingScanned(_GetAll):
+        per_returned = 'QUERY_TARGETING_SCANNED_PER_RETURNED'
+        objects_per_returned = 'QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED'
+
+    class TicketsAvailable(_GetAll):
+        reads = 'TICKETS_AVAILABLE_READS'
+        writes = 'TICKETS_AVAILABLE_WRITE'
+
+    class CPU(_GetAll):
+        class Process(_GetAll):
+            user = 'PROCESS_CPU_USER'
+            kernel = 'PROCESS_CPU_KERNEL'
+            children_user = 'PROCESS_CPU_CHILDREN_USER'
+            children_kernel = 'PROCESS_CPU_CHILDREN_KERNEL'
+
+        class ProcessNormalized(_GetAll):
+            user = 'PROCESS_NORMALIZED_CPU_USER'
+            kernel = 'PROCESS_NORMALIZED_CPU_KERNEL'
+            children_user = 'PROCESS_NORMALIZED_CPU_CHILDREN_USER'
+            children_kernel = 'PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL'
+
+        class System(_GetAll):
+            user = 'SYSTEM_CPU_USER'
+            kernel = 'SYSTEM_CPU_KERNEL'
+            nice = 'SYSTEM_CPU_NICE'
+            iowait = 'SYSTEM_CPU_IOWAIT'
+            irq = 'SYSTEM_CPU_IRQ'
+            softirq = 'SYSTEM_CPU_SOFTIRQ'
+            guest = 'SYSTEM_CPU_GUEST'
+            steal = 'SYSTEM_CPU_STEAL'
+
+        class SystemNormalized(_GetAll):
+            user = 'SYSTEM_NORMALIZED_CPU_USER'
+            kernel = 'SYSTEM_NORMALIZED_CPU_KERNEL'
+            nice = 'SYSTEM_NORMALIZED_CPU_NICE'
+            iowait = 'SYSTEM_NORMALIZED_CPU_IOWAIT'
+            irq = 'SYSTEM_NORMALIZED_CPU_IRQ'
+            softirq = 'SYSTEM_NORMALIZED_CPU_SOFTIRQ'
+            guest = 'SYSTEM_NORMALIZED_CPU_GUEST'
+            steal = 'SYSTEM_NORMALIZED_CPU_STEAL'
+
+
+class AtlasMeasurementValue(object):
+    def __init__(self, value_dict: dict):
+        """
+        Class for holding a measurement value
+        :type value_dict: dict
+        :param value_dict: An Atlas standard Measurement value dictionary.
+        """
+        timestamp: int = value_dict.get('timestamp', None)
+        value: float = value_dict.get('value', None)
+        try:
+            self.timestamp: datetime = parse(timestamp)
+        except (ValueError, TypeError):
+            logger.warning('Could not parse "{}" as a datetime.')
+            self.timestamp = None
+        try:
+            if value is None:
+                self.value = None
+            self.value: float = float(value)
+        except ValueError as e:
+            self.value = None
+            logger.warning('Could not parse the metric value "{}". Error was {}'.format(value, e))
+        except TypeError:
+            logger.info('Value is none.')
+            self.value = None
+
+    # noinspection PyBroadException
+    @property
+    def value_int(self) -> Optional[int]:
+        try:
+            return int(self.value)
+        except Exception as e:
+            return None
+
+    @property
+    def value_float(self) -> Optional[float]:
+        try:
+            return float(self.value)
+        except Exception:
+            return None
+
+    def as_dict(self) -> dict:
+        return dict(timestamp=self.timestamp.__str__(), value=self.value, value_int=self.value_int,
+                    value_float=self.value_float)
+
+    @property
+    def as_tuple(self) -> Tuple[datetime, OptionalFloat]:
+        """
+        Returns a MeasurementValue as a tuple, timestamp first.
+        :rtype: Tuple[datetime,OptionalFloat]
+        :return: A tuple with a datetime and a float
+        """
+        return self.timestamp, self.value
+
+
+class AtlasMeasurement(object):
+    """A point in time container for an Atlas measurement.
+
+            For a certain period, granularity and measurementType holds a list fo measurementValues.
+
+            Args:
+                name (AtlasMeasurementTypes): The name of the measurement type
+                period (AtlasPeriods): The period the measurement covers
+                granularity (AtlasGranularities): The granularity used for the measurement
+                measurements (List[AtlasMeasurementValue]): A list of the actual measurement values
+            """
+
+    def __init__(self, name: AtlasMeasurementTypes, period: AtlasPeriods,
+                 granularity: AtlasGranularities, measurements: List[AtlasMeasurementValue] = None):
+        if measurements is None:
+            measurements = list()
+        self.name: AtlasMeasurementTypes = name
+        self.period: AtlasPeriods = period
+        self.granularity: AtlasGranularities = granularity
+        self._measurements: List[AtlasMeasurementValue] = measurements
+
+    @property
+    def measurements(self) -> Iterable[AtlasMeasurementValue]:
+        """
+        Getter for the measurements.
+
+        Returns:
+            Iterator[AtlasMeasurementValue]: An iterator containing values objects.
+        """
+        for item in self._measurements:
+            yield item
+
+    @measurements.setter
+    def measurements(self, value):
+        if type(value) == list:
+            self._measurements.extend(value)
+        else:
+            self._measurements.append(value)
+
+    @measurements.deleter
+    def measurements(self):
+        self._measurements = []
+
+    def measurements_as_tuples(self):
+        if isinstance(self._measurements[0], AtlasMeasurementValue):
+            for item in self._measurements:
+                yield item.as_tuple
+
+    @property
+    def date_start(self):
+        """The date of the first measurement.
+
+        Returns:
+            datetime: The date of the first measurement.
+        """
+        seq = [x.timestamp for x in self._measurements]
+        return min(seq)
+
+    @property
+    def date_end(self):
+        """The date of the last measurement
+
+        Returns:
+            datetime: The date of the last measurement.
+
+        """
+        seq = [x.timestamp for x in self._measurements]
+        return max(seq)
+
+    @property
+    def measurements_count(self):
+        """The count of measurements
+
+        Returns:
+            int: The count of measurements in the set
+        """
+        return len(self._measurements)
+
+    @property
+    def as_dict(self):
+        """Returns the measurement as a dict, including the computed properties.
+
+        Returns:
+            dict:
+        """
+        return dict(measurements=self._measurements, date_start=self.date_start, date_end=self.date_end, name=self.name,
+                    period=self.period, granularity=self.granularity, measurements_count=self.measurements_count
+                    )
+
+    @property
+    def measurement_stats(self) -> StatisticalValues:
+        """Returns a statistical info for measurement data"""
+        data_list = list()
+        for each_measurement in self.measurements:
+            data_list.append(each_measurement.value_float)
+        return StatisticalValues(data_list=data_list)
+
+    @property
+    def measurement_stats_friendly_bytes(self) -> StatisticalValuesFriendly:
+        """Returns  statistical info for measurement data in friendly bytes format"""
+        data_list = list()
+        for each_measurement in self.measurements:
+            data_list.append(each_measurement.value_float)
+        return StatisticalValuesFriendly(data_list=data_list)
+
+    @property
+    def measurement_stats_friendly_number(self) -> StatisticalValuesFriendly:
+        """Returns  statistical info for measurement data in friendly bytes format"""
+        data_list = list()
+        for each_measurement in self.measurements:
+            data_list.append(each_measurement.value_float)
+        return StatisticalValuesFriendly(data_list=data_list, data_type='number')
+
+    def __hash__(self):
+        return hash(self.name + '-' + self.period)
+
+    def __eq__(self, other):
+        """
+        Measurements are considered duplicate of name and period are the same
+        :param other:
+        :return:
+        """
+        if isinstance(other, AtlasMeasurement):
+            return ((self.name == other.name) and (self.period == other.period))
+
+
+ListOfAtlasMeasurementValues = NewType('ListOfAtlasMeasurementValues', List[Optional[AtlasMeasurementValue]])
+OptionalAtlasMeasurement = NewType('OptionalAtlasMeasurement', Optional[AtlasMeasurement])
+
+
+def clean_list(data_list: list) -> list:
+    """Returns a list with any none values removed
+
+    Args:
+        data_list (list): The list to be cleaned
+
+    Returns (list): The list cleaned of None values.
+
+    """
+    return list(filter(None, data_list))

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -38,8 +38,8 @@ class StatisticalValuesFriendly:
         """
         try:
             if data_type is None:
-                data_type = 'bytes'
-            if data_type == 'bytes':
+                data_type = 'SCALAR_PER_SECOND'
+            if data_type == 'BYTES':
                 self.mean: str = hf.format_size(mean(clean_list(data_list)))
                 self.min: str = hf.format_size(min(clean_list(data_list)))
                 self.max: str = hf.format_size(max(clean_list(data_list)))
@@ -47,6 +47,7 @@ class StatisticalValuesFriendly:
                 self.mean: str = hf.format_number(mean(clean_list(data_list)))
                 self.min: str = hf.format_number(min(clean_list(data_list)))
                 self.max: str = hf.format_number(max(clean_list(data_list)))
+
         except StatisticsError:
             logger.warning('Could not compute statistical values.')
             self.mean: str = 'No Value'
@@ -242,16 +243,18 @@ class AtlasMeasurement(object):
 
             Args:
                 name (AtlasMeasurementTypes): The name of the measurement type
+                units (Text): Descriptive text of units used.
                 period (AtlasPeriods): The period the measurement covers
                 granularity (AtlasGranularities): The granularity used for the measurement
                 measurements (List[AtlasMeasurementValue]): A list of the actual measurement values
             """
 
     def __init__(self, name: AtlasMeasurementTypes, period: AtlasPeriods,
-                 granularity: AtlasGranularities, measurements: List[AtlasMeasurementValue] = None):
+                 granularity: AtlasGranularities, units: str = None, measurements: List[AtlasMeasurementValue] = None):
         if measurements is None:
             measurements = list()
         self.name: AtlasMeasurementTypes = name
+        self.units: str = units
         self.period: AtlasPeriods = period
         self.granularity: AtlasGranularities = granularity
         self._measurements: List[AtlasMeasurementValue] = measurements
@@ -321,7 +324,8 @@ class AtlasMeasurement(object):
             dict:
         """
         return dict(measurements=self._measurements, date_start=self.date_start, date_end=self.date_end, name=self.name,
-                    period=self.period, granularity=self.granularity, measurements_count=self.measurements_count
+                    units= self.units, period=self.period, granularity=self.granularity,
+                    measurements_count=self.measurements_count
                     )
 
     @property
@@ -333,20 +337,14 @@ class AtlasMeasurement(object):
         return StatisticalValues(data_list=data_list)
 
     @property
-    def measurement_stats_friendly_bytes(self) -> StatisticalValuesFriendly:
+    def measurement_stats_friendly(self) -> StatisticalValuesFriendly:
         """Returns  statistical info for measurement data in friendly bytes format"""
         data_list = list()
         for each_measurement in self.measurements:
             data_list.append(each_measurement.value_float)
-        return StatisticalValuesFriendly(data_list=data_list)
+        return StatisticalValuesFriendly(data_list=data_list,data_type=self.units)
 
-    @property
-    def measurement_stats_friendly_number(self) -> StatisticalValuesFriendly:
-        """Returns  statistical info for measurement data in friendly bytes format"""
-        data_list = list()
-        for each_measurement in self.measurements:
-            data_list.append(each_measurement.value_float)
-        return StatisticalValuesFriendly(data_list=data_list, data_type='number')
+
 
     def __hash__(self):
         return hash(self.name + '-' + self.period)

--- a/atlasapi/measurements.py
+++ b/atlasapi/measurements.py
@@ -43,6 +43,10 @@ class StatisticalValuesFriendly:
                 self.mean: str = hf.format_size(mean(clean_list(data_list)))
                 self.min: str = hf.format_size(min(clean_list(data_list)))
                 self.max: str = hf.format_size(max(clean_list(data_list)))
+            elif data_type == 'SCALAR':
+                self.mean: str = hf.format_number(mean(clean_list(data_list)))
+                self.min: str = hf.format_number(min(clean_list(data_list)))
+                self.max: str = hf.format_number(max(clean_list(data_list)))
             else:
                 self.mean: str = hf.format_number(mean(clean_list(data_list)))
                 self.min: str = hf.format_number(min(clean_list(data_list)))

--- a/atlasapi/network.py
+++ b/atlasapi/network.py
@@ -145,10 +145,10 @@ class Network:
             logger.debug("Auth information = {} {}".format(self.user, self.password))
 
             return self.answer(r.status_code, r.json())
-        except Exception:
+        except Exception as e:
             logger.warning('Request: {}'.format(r.request.__dict__))
             logger.warning('Response: {}'.format(r.__dict__))
-            raise
+            raise e
         finally:
             if r:
                 r.connection.close()

--- a/atlasapi/network.py
+++ b/atlasapi/network.py
@@ -31,6 +31,9 @@ logger = logging.getLogger('network')
 logger.setLevel(logging.WARNING)
 
 
+def merge(dict1, dict2):
+    return dict2.update(dict1)
+
 class Network:
     """Network constructor
     
@@ -153,7 +156,7 @@ class Network:
             if r:
                 r.connection.close()
 
-    def get_big(self, uri):
+    def get_big(self, uri, params: dict = None):
         """Get request (max results)
 
         This is a temporary fix until we re-factor pagination.
@@ -168,21 +171,27 @@ class Network:
             Exception: Network issue
         """
         r = None
+        print(f"Revieved the following parameters {params}")
+        if params:
+            logger.warning(f"Revieved the following parameters {params}")
+            merge({'itemsPerPage': Settings.itemsPerPage},params)
+            logger.warning(f"The parameters are now {params}")
+        else:
+            params = {'itemsPerPage': Settings.itemsPerPage}
 
         try:
+            logger.warning(f"The parameters object is {params}")
             r = requests.get(uri,
                              allow_redirects=True,
-                             params= {'itemsPerPage': Settings.itemsPerPage},
+                             params=params,
                              timeout=Settings.requests_timeout,
                              headers={},
                              auth=self.auth_method(self.user, self.password))
             logger.debug("Auth information = {} {}".format(self.user, self.password))
 
             return self.answer(r.status_code, r.json())
-        except Exception:
-            logger.warning('Request: {}'.format(r.request.__dict__))
-            logger.warning('Response: {}'.format(r.__dict__))
-            raise
+        except Exception as e:
+            raise e
         finally:
             if r:
                 r.connection.close()

--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -51,7 +51,7 @@ class Settings:
             "Get Measurements of a Disk for Process": "/api/atlas/v1.0/groups/{group_id}/processes/{host}:{port}/disks/"
                                                       "{disk_name}/measurements",
             "Get Measurements of a Database for Process": "/api/atlas/v1.0/groups/{group_id}/processes/{host}:{port}/"
-                                                          "databases/database_name}/measurements",
+                                                          "databases/{database_name}/measurements",
             "Get Available Databases for Process": "/api/atlas/v1.0/groups/{group_id}/processes/"
                                                    "{host}:{port}/databases"
         },

--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -46,10 +46,10 @@ class Settings:
                                             "DISK-NAME}/measurements",
             "Get the log file for a host in the cluster": "/api/atlas/v1.0/groups/{group_id}/clusters/{"
                                                           "host}/logs/{logname}",
-            "Get Available Disks for Process": "GET api/atlas/v1.0/groups/{group_id}/processes/"
-                                                       "{host}:{port}/disks",
-            "Get Measurements of a Disk for Process" : "GET /groups/{group_id}/processes/{host}:{port}/disks/"
-                                                       "{disk_name}/measurements"
+            "Get Available Disks for Process": "/api/atlas/v1.0/groups/{group_id}/processes/"
+                                               "{host}:{port}/disks",
+            "Get Measurements of a Disk for Process": "/api/atlas/v1.0/groups/{group_id}/processes/{host}:{port}/disks/"
+                                                      "{disk_name}/measurements"
         },
         "Events": {
             "Get All Project Events": URI_STUB + "/groups/{group_id}/events??includeRaw=true&pageNum={page_num}"
@@ -160,7 +160,7 @@ class Settings:
 
     # Atlas default pagination
     pageNum = 1
-    itemsPerPage: int  = int(os.getenv('ITEMS_PER_PAGE', 500))
+    itemsPerPage: int = int(os.getenv('ITEMS_PER_PAGE', 500))
     itemsPerPageMin: int = int(os.getenv('ITEMS_PER_PAGE_MIN', 1))
     itemsPerPageMax: int = int(os.getenv('ITEMS_PER_PAGE_MAX', 2000))
 

--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -45,7 +45,11 @@ class Settings:
             "Get measurements of for host": "/api/atlas/v1.0/groups/{GROUP-ID}/processes/{HOST}:{PORT}/disks/{"
                                             "DISK-NAME}/measurements",
             "Get the log file for a host in the cluster": "/api/atlas/v1.0/groups/{group_id}/clusters/{"
-                                                          "host}/logs/{logname}"
+                                                          "host}/logs/{logname}",
+            "Get Available Disks for Process": "GET api/atlas/v1.0/groups/{group_id}/processes/"
+                                                       "{host}:{port}/disks",
+            "Get Measurements of a Disk for Process" : "GET /groups/{group_id}/processes/{host}:{port}/disks/"
+                                                       "{disk_name}/measurements"
         },
         "Events": {
             "Get All Project Events": URI_STUB + "/groups/{group_id}/events??includeRaw=true&pageNum={page_num}"

--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -49,7 +49,11 @@ class Settings:
             "Get Available Disks for Process": "/api/atlas/v1.0/groups/{group_id}/processes/"
                                                "{host}:{port}/disks",
             "Get Measurements of a Disk for Process": "/api/atlas/v1.0/groups/{group_id}/processes/{host}:{port}/disks/"
-                                                      "{disk_name}/measurements"
+                                                      "{disk_name}/measurements",
+            "Get Measurements of a Database for Process": "/api/atlas/v1.0/groups/{group_id}/processes/{host}:{port}/"
+                                                          "databases/database_name}/measurements",
+            "Get Available Databases for Process": "/api/atlas/v1.0/groups/{group_id}/processes/"
+                                                   "{host}:{port}/databases"
         },
         "Events": {
             "Get All Project Events": URI_STUB + "/groups/{group_id}/events??includeRaw=true&pageNum={page_num}"

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -33,7 +33,7 @@ from atlasapi.errors import ErrRole
 from enum import Enum
 from dateutil import parser
 from atlasapi.atlas_types import *
-from typing import Optional, NewType, List, Union, Iterable, BinaryIO
+from typing import Optional, NewType, List, Union, Iterable, BinaryIO, Any
 from datetime import datetime
 from atlasapi.lib import AtlasGranularities, AtlasPeriods, AtlasLogNames
 import logging
@@ -276,16 +276,18 @@ class Host(object):
 
     def get_measurements_for_disk(self, atlas_obj, partition_name: str,
                                   granularity: Optional[AtlasGranularities] = None,
-                                  period: Optional[AtlasPeriods] = None, iterable: bool = True) -> Iterable[str]:
-        """Returns All Metrics for the hosts partition.
+                                  period: Optional[AtlasPeriods] = None, iterable: bool = True) -> \
+            Iterable[Union[AtlasMeasurement, Any]]:
+        """Returns All Metrics for a Hosts partition, for a given period and granularity.
 
+        Uses default granularity and period if not passed.
 
         Args:
-            iterable:
+            iterable (bool): Defaults to true, if not true will return the raw response from API.
             partition_name: The Atlas partition name (commonly `data`)
             period (Optional[AtlasPeriods]):The period for the disk measurements
             granularity (Optional[AtlasGranularitues]): The granularity for the disk measurements.
-            atlas_obj : A configured Atlas instance to connect to the API with.
+            atlas_obj (atlasapi.atlas.Atlas): A configured Atlas instance to connect to the API with.
 
         Returns:
             List[str]: A list of partition names.
@@ -325,6 +327,23 @@ class Host(object):
                 yield measurement_obj
 
         return return_val
+
+    def data_partition_stats(self, atlas_obj, granularity: Optional[AtlasGranularities] = None,
+                             period: Optional[AtlasPeriods] = None, ) -> Iterable[AtlasMeasurement]:
+        """Returns disk measurements for the data partition of the host.
+
+        Hard codes the name of the partition to `data` and returns all metrics.
+
+        Args:
+            atlas_obj: Instantiated Atlas instance to access the API
+            granularity (Optional[AtlasGranularitues]): The granularity for the disk measurements.
+            atlas_obj (atlasapi.atlas.Atlas): A configured Atlas instance to connect to the API with.
+
+        Returns (Iterable[AtlasMeasurement]): A generator yielding AtlasMeasurements
+
+        """
+        return self.get_measurements_for_disk(atlas_obj=atlas_obj, partition_name='data', granularity=granularity,
+                                             period=period)
 
     def __hash__(self):
         return hash(self.hostname)

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -252,15 +252,12 @@ class Host(object):
             self.log_files.append(log_obj)
 
     def get_partitions(self, atlas_obj) -> Iterable[str]:
-        """Returns all disks(partitions) configured on the Atlas Host
-
-        Yields names of partitions, and appends them to the partitions property.
-
+        """Returns names of all disks(partitions) configured on the Atlas Host
         Args:
             atlas_obj :
 
         Returns:
-            List[str]: A list of partition names.
+            Iterable[str]: A list of partition names.
         """
         uri = Settings.api_resources["Monitoring and Logs"]["Get Available Disks for Process"].format(
             group_id=self.group_id,
@@ -269,7 +266,6 @@ class Host(object):
         )
         logger.info(f"The full URI being called is {Settings.BASE_URL + uri}")
         return_val = atlas_obj.network.get(Settings.BASE_URL + uri)
-        partition_list: List[Optional[str]] = []
         for each_partition in return_val.get("results"):
             partition_name: str = each_partition.get('partitionName', None)
             yield partition_name
@@ -344,6 +340,28 @@ class Host(object):
         """
         return self.get_measurements_for_disk(atlas_obj=atlas_obj, partition_name='data', granularity=granularity,
                                              period=period)
+
+    def get_databases(self, atlas_obj) -> Iterable[str]:
+        """Returns all disks(partitions) configured on the Atlas Host
+
+        Yields names of databases, and appends them to the databa
+
+        Args:
+            atlas_obj :
+
+        Returns:
+            List[str]: A list of database names.
+        """
+        uri = Settings.api_resources["Monitoring and Logs"]["Get Available Databases for Process"].format(
+            group_id=self.group_id,
+            host=self.hostname,
+            port=self.port,
+        )
+        logger.info(f"The full URI being called is {Settings.BASE_URL + uri}")
+        return_val = atlas_obj.network.get(Settings.BASE_URL + uri)
+        for each_database in return_val.get("results"):
+            db_name  = each_database.get('databaseName', None)
+            yield db_name
 
     def __hash__(self):
         return hash(self.hostname)

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -28,6 +28,7 @@ from builtins import str
 
 from dateutil.parser import parse
 
+import atlasapi.atlas
 from atlasapi.atlas_types import OptionalFloat
 from atlasapi.lib import AtlasPeriods, AtlasGranularities, logger, _GetAll
 
@@ -38,7 +39,7 @@ from datetime import datetime
 from enum import Enum
 from dateutil import parser
 from atlasapi.atlas_types import *
-from typing import Optional, NewType, List, Any, Union, Iterable, BinaryIO, Tuple, Generator
+from typing import Optional, NewType, List, Any, Union, Iterable, BinaryIO, Tuple, Generator, Set
 from datetime import datetime
 import isodate
 from atlasapi.lib import AtlasGranularities, AtlasPeriods, AtlasLogNames
@@ -621,6 +622,31 @@ class Host(object):
             self.log_files = [log_obj]
         else:
             self.log_files.append(log_obj)
+
+    def get_partitions(self, atlas_obj) -> Iterable[str]:
+        """Returns all disks(partitions) configured on the Atlas Host
+
+        Yields names of partitions, and appends them to the partitions property.
+
+        Args:
+            atlas_obj :
+
+        Returns:
+            List[str]: A list of partition names.
+        """
+        uri = Settings.api_resources["Monitoring and Logs"]["Get Available Disks for Process"].format(
+            group_id=self.group_id,
+            host=self.hostname,
+            port=self.port,
+        )
+        logger.info(f"The full URI being called is {Settings.BASE_URL + uri}")
+        return_val = atlas_obj.network.get(Settings.BASE_URL + uri)
+        partition_list: List[Optional[str]] = []
+        for each_partition in return_val.get("results"):
+            partition_name: str = each_partition.get('partitionName', None)
+            yield partition_name
+
+
 
     def __hash__(self):
         return hash(self.hostname)

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -23,50 +23,30 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from builtins import open
 from builtins import str
 
-from dateutil.parser import parse
-
-import atlasapi.atlas
-from atlasapi.atlas_types import OptionalFloat
-from atlasapi.lib import AtlasPeriods, AtlasGranularities, logger, _GetAll
+from atlasapi.lib import logger
 
 from atlasapi.settings import Settings
 from atlasapi.errors import ErrRole
 
-from datetime import datetime
 from enum import Enum
 from dateutil import parser
 from atlasapi.atlas_types import *
-from typing import Optional, NewType, List, Any, Union, Iterable, BinaryIO, Tuple, Generator, Set
+from typing import Optional, NewType, List, Union, Iterable, BinaryIO
 from datetime import datetime
-import isodate
 from atlasapi.lib import AtlasGranularities, AtlasPeriods, AtlasLogNames
 import logging
 from future import standard_library
-import humanfriendly as hf
 from logging import Logger
-from statistics import mean
-from statistics import StatisticsError
+
+from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
 
 standard_library.install_aliases()
 logger: Logger = logging.getLogger('Atlas.specs')
 
 
 # etc., as needed
-
-
-def clean_list(data_list: list) -> list:
-    """Returns a list with any none values removed
-
-    Args:
-        data_list (list): The list to be cleaned
-
-    Returns (list): The list cleaned of None values.
-
-    """
-    return list(filter(None, data_list))
 
 
 class IAMType(Enum):
@@ -101,359 +81,6 @@ class HostLogFile(object):
         self.log_name = log_name
 
 
-class StatisticalValues:
-    def __init__(self, data_list: list):
-        try:
-            self.samples: int = len(clean_list(data_list))
-            self.mean: float = float(mean(clean_list(data_list)))
-            self.min: float = float(min(clean_list(data_list)))
-            self.max: float = float(max(clean_list(data_list)))
-        except StatisticsError:
-            logger.warning('Could not compute statistical values.')
-            self.samples: int = 0
-            self.mean: int = 0
-            self.min: float = 0
-            self.max: float = 0
-
-
-class StatisticalValuesFriendly:
-    def __init__(self, data_list: list, data_type: str = None) -> None:
-        """Returns human-readable values for stats
-
-        Args:
-            data_list:
-            data_type: The datatype either bytes or number
-        """
-        try:
-            if data_type is None:
-                data_type = 'bytes'
-            if data_type == 'bytes':
-                self.mean: str = hf.format_size(mean(clean_list(data_list)))
-                self.min: str = hf.format_size(min(clean_list(data_list)))
-                self.max: str = hf.format_size(max(clean_list(data_list)))
-            else:
-                self.mean: str = hf.format_number(mean(clean_list(data_list)))
-                self.min: str = hf.format_number(min(clean_list(data_list)))
-                self.max: str = hf.format_number(max(clean_list(data_list)))
-        except StatisticsError:
-            logger.warning('Could not compute statistical values.')
-            self.mean: str = 'No Value'
-            self.min: str = 'No value'
-            self.max: str = 'No value'
-
-
-class AtlasMeasurementTypes(_GetAll):
-    """
-    Helper class for all available atlas measurements.
-
-    All classes and embedded classes have a get_all class method that returns an iterator of all measurements
-    and sub measurements.
-
-    """
-    connections = 'CONNECTIONS'
-
-    class Asserts(_GetAll):
-        regular = 'ASSERT_REGULAR'
-        warning = 'ASSERT_WARNING'
-        msg = 'ASSERT_MSG'
-        user = 'ASSERT_USER'
-
-    class Cache(_GetAll):
-        bytes_read = 'CACHE_BYTES_READ_INTO'
-        bytes_written = 'CACHE_BYTES_WRITTEN_FROM'
-        dirty = 'CACHE_DIRTY_BYTES'
-        used = 'CACHE_USED_BYTES'
-
-    class Cursors(_GetAll):
-        open = 'CURSORS_TOTAL_OPEN'
-        timed_out = 'CURSORS_TOTAL_TIMED_OUT'
-
-    class Db(_GetAll):
-        storage = 'DB_STORAGE_TOTAL'
-        data_size = 'DB_DATA_SIZE_TOTAL'
-
-    class DocumentMetrics(_GetAll):
-        returned = 'DOCUMENT_METRICS_RETURNED'
-        inserted = 'DOCUMENT_METRICS_INSERTED'
-        updated = 'DOCUMENT_METRICS_UPDATED'
-        deleted = 'DOCUMENT_METRICS_DELETED'
-
-    class ExtraInfo(_GetAll):
-        page_faults = 'EXTRA_INFO_PAGE_FAULTS'
-
-    class GlobalLockCurrentQueue(_GetAll):
-        total = 'GLOBAL_LOCK_CURRENT_QUEUE_TOTAL'
-        readers = 'GLOBAL_LOCK_CURRENT_QUEUE_READERS'
-        writers = 'GLOBAL_LOCK_CURRENT_QUEUE_WRITERS'
-
-    class Memory(_GetAll):
-        resident = 'MEMORY_RESIDENT'
-        virtual = 'MEMORY_VIRTUAL'
-        mapped = 'MEMORY_MAPPED'
-
-    class Network(_GetAll):
-        bytes_id = 'NETWORK_BYTES_IN'  # initial typo, kept for backwards compatibility
-        bytes_in = 'NETWORK_BYTES_IN'
-        bytes_out = 'NETWORK_BYTES_OUT'
-        num_requests = 'NETWORK_NUM_REQUESTS'
-
-    class Opcounter(_GetAll):
-        cmd = 'OPCOUNTER_CMD'
-        query = 'OPCOUNTER_QUERY'
-        update = 'OPCOUNTER_UPDATE'
-        delete = 'OPCOUNTER_DELETE'
-        getmore = 'OPCOUNTER_GETMORE'
-        insert = 'OPCOUNTER_INSERT'
-
-        class Repl(_GetAll):
-            cmd = 'OPCOUNTER_REPL_CMD'
-            update = 'OPCOUNTER_REPL_UPDATE'
-            delete = 'OPCOUNTER_REPL_DELETE'
-            insert = 'OPCOUNTER_REPL_INSERT'
-
-    class Operations(_GetAll):
-        scan_and_order = 'OPERATIONS_SCAN_AND_ORDER'
-
-        class ExecutionTime(_GetAll):
-            reads = 'OP_EXECUTION_TIME_READS'
-            writes = 'OP_EXECUTION_TIME_WRITES'
-            commands = 'OP_EXECUTION_TIME_COMMANDS'
-
-    class Oplog(_GetAll):
-        master_time = 'OPLOG_MASTER_TIME'
-        rate = 'OPLOG_RATE_GB_PER_HOUR'
-
-    class QueryExecutor(_GetAll):
-        scanned = 'QUERY_EXECUTOR_SCANNED'
-        scanned_objects = 'QUERY_EXECUTOR_SCANNED_OBJECTS'
-
-    class QueryTargetingScanned(_GetAll):
-        per_returned = 'QUERY_TARGETING_SCANNED_PER_RETURNED'
-        objects_per_returned = 'QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED'
-
-    class TicketsAvailable(_GetAll):
-        reads = 'TICKETS_AVAILABLE_READS'
-        writes = 'TICKETS_AVAILABLE_WRITE'
-
-    class CPU(_GetAll):
-        class Process(_GetAll):
-            user = 'PROCESS_CPU_USER'
-            kernel = 'PROCESS_CPU_KERNEL'
-            children_user = 'PROCESS_CPU_CHILDREN_USER'
-            children_kernel = 'PROCESS_CPU_CHILDREN_KERNEL'
-
-        class ProcessNormalized(_GetAll):
-            user = 'PROCESS_NORMALIZED_CPU_USER'
-            kernel = 'PROCESS_NORMALIZED_CPU_KERNEL'
-            children_user = 'PROCESS_NORMALIZED_CPU_CHILDREN_USER'
-            children_kernel = 'PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL'
-
-        class System(_GetAll):
-            user = 'SYSTEM_CPU_USER'
-            kernel = 'SYSTEM_CPU_KERNEL'
-            nice = 'SYSTEM_CPU_NICE'
-            iowait = 'SYSTEM_CPU_IOWAIT'
-            irq = 'SYSTEM_CPU_IRQ'
-            softirq = 'SYSTEM_CPU_SOFTIRQ'
-            guest = 'SYSTEM_CPU_GUEST'
-            steal = 'SYSTEM_CPU_STEAL'
-
-        class SystemNormalized(_GetAll):
-            user = 'SYSTEM_NORMALIZED_CPU_USER'
-            kernel = 'SYSTEM_NORMALIZED_CPU_KERNEL'
-            nice = 'SYSTEM_NORMALIZED_CPU_NICE'
-            iowait = 'SYSTEM_NORMALIZED_CPU_IOWAIT'
-            irq = 'SYSTEM_NORMALIZED_CPU_IRQ'
-            softirq = 'SYSTEM_NORMALIZED_CPU_SOFTIRQ'
-            guest = 'SYSTEM_NORMALIZED_CPU_GUEST'
-            steal = 'SYSTEM_NORMALIZED_CPU_STEAL'
-
-
-class AtlasMeasurementValue(object):
-    def __init__(self, value_dict: dict):
-        """
-        Class for holding a measurement value
-        :type value_dict: dict
-        :param value_dict: An Atlas standard Measurement value dictionary.
-        """
-        timestamp: int = value_dict.get('timestamp', None)
-        value: float = value_dict.get('value', None)
-        try:
-            self.timestamp: datetime = parse(timestamp)
-        except (ValueError, TypeError):
-            logger.warning('Could not parse "{}" as a datetime.')
-            self.timestamp = None
-        try:
-            if value is None:
-                self.value = None
-            self.value: float = float(value)
-        except ValueError as e:
-            self.value = None
-            logger.warning('Could not parse the metric value "{}". Error was {}'.format(value, e))
-        except TypeError:
-            logger.info('Value is none.')
-            self.value = None
-
-    # noinspection PyBroadException
-    @property
-    def value_int(self) -> Optional[int]:
-        try:
-            return int(self.value)
-        except Exception as e:
-            return None
-
-    @property
-    def value_float(self) -> Optional[float]:
-        try:
-            return float(self.value)
-        except Exception:
-            return None
-
-    def as_dict(self) -> dict:
-        return dict(timestamp=self.timestamp.__str__(), value=self.value, value_int=self.value_int,
-                    value_float=self.value_float)
-
-    @property
-    def as_tuple(self) -> Tuple[datetime, OptionalFloat]:
-        """
-        Returns a MeasurementValue as a tuple, timestamp first.
-        :rtype: Tuple[datetime,OptionalFloat]
-        :return: A tuple with a datetime and a float
-        """
-        return self.timestamp, self.value
-
-
-class AtlasMeasurement(object):
-    """A point in time container for an Atlas measurement.
-
-            For a certain period, granularity and measurementType holds a list fo measurementValues.
-
-            Args:
-                name (AtlasMeasurementTypes): The name of the measurement type
-                period (AtlasPeriods): The period the measurement covers
-                granularity (AtlasGranularities): The granularity used for the measurement
-                measurements (List[AtlasMeasurementValue]): A list of the actual measurement values
-            """
-
-    def __init__(self, name: AtlasMeasurementTypes, period: AtlasPeriods,
-                 granularity: AtlasGranularities, measurements: List[AtlasMeasurementValue] = None):
-        if measurements is None:
-            measurements = list()
-        self.name: AtlasMeasurementTypes = name
-        self.period: AtlasPeriods = period
-        self.granularity: AtlasGranularities = granularity
-        self._measurements: List[AtlasMeasurementValue] = measurements
-
-    @property
-    def measurements(self) -> Iterable[AtlasMeasurementValue]:
-        """
-        Getter for the measurements.
-
-        Returns:
-            Iterator[AtlasMeasurementValue]: An iterator containing values objects.
-        """
-        for item in self._measurements:
-            yield item
-
-    @measurements.setter
-    def measurements(self, value):
-        if type(value) == list:
-            self._measurements.extend(value)
-        else:
-            self._measurements.append(value)
-
-    @measurements.deleter
-    def measurements(self):
-        self._measurements = []
-
-    def measurements_as_tuples(self):
-        if isinstance(self._measurements[0], AtlasMeasurementValue):
-            for item in self._measurements:
-                yield item.as_tuple
-
-    @property
-    def date_start(self):
-        """The date of the first measurement.
-
-        Returns:
-            datetime: The date of the first measurement.
-        """
-        seq = [x.timestamp for x in self._measurements]
-        return min(seq)
-
-    @property
-    def date_end(self):
-        """The date of the last measurement
-
-        Returns:
-            datetime: The date of the last measurement.
-
-        """
-        seq = [x.timestamp for x in self._measurements]
-        return max(seq)
-
-    @property
-    def measurements_count(self):
-        """The count of measurements
-
-        Returns:
-            int: The count of measurements in the set
-        """
-        return len(self._measurements)
-
-    @property
-    def as_dict(self):
-        """Returns the measurement as a dict, including the computed properties.
-
-        Returns:
-            dict:
-        """
-        return dict(measurements=self._measurements, date_start=self.date_start, date_end=self.date_end, name=self.name,
-                    period=self.period, granularity=self.granularity, measurements_count=self.measurements_count
-                    )
-
-    @property
-    def measurement_stats(self) -> StatisticalValues:
-        """Returns a statistical info for measurement data"""
-        data_list = list()
-        for each_measurement in self.measurements:
-            data_list.append(each_measurement.value_float)
-        return StatisticalValues(data_list=data_list)
-
-    @property
-    def measurement_stats_friendly_bytes(self) -> StatisticalValuesFriendly:
-        """Returns  statistical info for measurement data in friendly bytes format"""
-        data_list = list()
-        for each_measurement in self.measurements:
-            data_list.append(each_measurement.value_float)
-        return StatisticalValuesFriendly(data_list=data_list)
-
-    @property
-    def measurement_stats_friendly_number(self) -> StatisticalValuesFriendly:
-        """Returns  statistical info for measurement data in friendly bytes format"""
-        data_list = list()
-        for each_measurement in self.measurements:
-            data_list.append(each_measurement.value_float)
-        return StatisticalValuesFriendly(data_list=data_list, data_type='number')
-
-    def __hash__(self):
-        return hash(self.name + '-' + self.period)
-
-    def __eq__(self, other):
-        """
-        Measurements are considered duplicate of name and period are the same
-        :param other:
-        :return:
-        """
-        if isinstance(other, AtlasMeasurement):
-            return ((self.name == other.name) and (self.period == other.period))
-
-
-ListOfAtlasMeasurementValues = NewType('ListOfAtlasMeasurementValues', List[Optional[AtlasMeasurementValue]])
-
-OptionalAtlasMeasurement = NewType('OptionalAtlasMeasurement', Optional[AtlasMeasurement])
-
-
 class Host(object):
     def __init__(self, data: dict) -> None:
         """An Atlas Host
@@ -476,7 +103,7 @@ class Host(object):
             port (int): The TCP port the instance is running on.
             replica_set_name (str): The name of the replica set running on the instance
             type (ReplicaSetTypes): The type of replica set this intstance is a member of
-            measurements (Optional[List[AtlasMeasurement]]: Holds list of host Measurements
+            measurements (Optional[List[measurements.AtlasMeasurement]]: Holds list of host Measurements
             cluster_name (str): The cluster name (taken from the hostname)
             cluster_name_alias (str) : The cluster name user alias, taken from the hostname user friendly alias.
             log_files (Optional[List[HostLogFile]]): Holds list of log files when requested.
@@ -646,7 +273,56 @@ class Host(object):
             partition_name: str = each_partition.get('partitionName', None)
             yield partition_name
 
+    def get_measurements_for_disk(self, atlas_obj, partition_name: str,
+                                  granularity: Optional[AtlasGranularities] = None,
+                                  period: Optional[AtlasPeriods] = None, iterable: bool = True) -> Iterable[str]:
+        """Returns All Metrics for the hosts partition.
 
+
+        Args:
+            iterable:
+            partition_name: The Atlas partition name (commonly `data`)
+            period (Optional[AtlasPeriods]):The period for the disk measurements
+            granularity (Optional[AtlasGranularitues]): The granularity for the disk measurements.
+            atlas_obj : A configured Atlas instance to connect to the API with.
+
+        Returns:
+            List[str]: A list of partition names.
+        """
+        if period is None:
+            period = AtlasPeriods.WEEKS_1
+        logger.info(f'The granularity is {granularity}')
+
+        if granularity is None:
+            granularity = AtlasGranularities.HOUR
+        logger.info(f'The granularity is {granularity}')
+        parameters = {'granularity': granularity, 'period': period}
+        uri = Settings.api_resources["Monitoring and Logs"]["Get Measurements of a Disk for Process"].format(
+            group_id=self.group_id,
+            host=self.hostname,
+            port=self.port,
+            disk_name=partition_name,
+        )
+        logger.info(f"The full URI being called is {Settings.BASE_URL + uri}")
+        logger.info(f"We sent the following parameters: {parameters}")
+        return_val = atlas_obj.network.get_big(Settings.BASE_URL + uri, params=parameters)
+
+        measurement_obj = None
+        if iterable:
+            measurements = return_val.get('measurements')
+            measurements_count = len(measurements)
+            logger.warning('There are {} measurements.'.format(measurements_count))
+
+            for each in measurements:
+                measurement_obj = AtlasMeasurement(name=each.get('name'),
+                                                   period=period,
+                                                   granularity=granularity)
+                for each_and_every in each.get('dataPoints'):
+                    measurement_obj.measurements = AtlasMeasurementValue(each_and_every)
+
+            yield measurement_obj
+
+        return return_val
 
     def __hash__(self):
         return hash(self.hostname)

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -40,7 +40,7 @@ import logging
 from future import standard_library
 from logging import Logger
 
-from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
+from atlasapi.measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
 
 standard_library.install_aliases()
 logger: Logger = logging.getLogger('Atlas.specs')
@@ -222,6 +222,7 @@ class Host(object):
 
             for each in measurements:
                 measurement_obj = AtlasMeasurement(name=each.get('name'),
+                                                   units=each.get('units', None),
                                                    period=period,
                                                    granularity=granularity)
                 for each_and_every in each.get('dataPoints'):

--- a/atlasapi/specs.py
+++ b/atlasapi/specs.py
@@ -296,6 +296,7 @@ class Host(object):
         if granularity is None:
             granularity = AtlasGranularities.HOUR
         logger.info(f'The granularity is {granularity}')
+
         parameters = {'granularity': granularity, 'period': period}
         uri = Settings.api_resources["Monitoring and Logs"]["Get Measurements of a Disk for Process"].format(
             group_id=self.group_id,
@@ -312,15 +313,15 @@ class Host(object):
             measurements = return_val.get('measurements')
             measurements_count = len(measurements)
             logger.warning('There are {} measurements.'.format(measurements_count))
-
             for each in measurements:
                 measurement_obj = AtlasMeasurement(name=each.get('name'),
                                                    period=period,
-                                                   granularity=granularity)
+                                                   granularity=granularity,
+                                                   units=each.get('units', None))
                 for each_and_every in each.get('dataPoints'):
                     measurement_obj.measurements = AtlasMeasurementValue(each_and_every)
 
-            yield measurement_obj
+                yield measurement_obj
 
         return return_val
 

--- a/tests/monitoring_logs.py
+++ b/tests/monitoring_logs.py
@@ -18,7 +18,7 @@ USER = getenv('ATLAS_USER', None)
 API_KEY = getenv('ATLAS_KEY', None)
 GROUP_ID = getenv('ATLAS_GROUP', None)
 from atlasapi.lib import AtlasPeriods, AtlasUnits, AtlasGranularities
-from measurements import AtlasMeasurementTypes
+from atlasapi.measurements import AtlasMeasurementTypes
 import csv
 if not USER or not API_KEY or not GROUP_ID:
     raise EnvironmentError('In order to run this smoke test you need ATLAS_USER, AND ATLAS_KEY env variables'

--- a/tests/monitoring_logs.py
+++ b/tests/monitoring_logs.py
@@ -18,7 +18,7 @@ USER = getenv('ATLAS_USER', None)
 API_KEY = getenv('ATLAS_KEY', None)
 GROUP_ID = getenv('ATLAS_GROUP', None)
 from atlasapi.lib import AtlasPeriods, AtlasUnits, AtlasGranularities
-from specs import AtlasMeasurementTypes
+from measurements import AtlasMeasurementTypes
 import csv
 if not USER or not API_KEY or not GROUP_ID:
     raise EnvironmentError('In order to run this smoke test you need ATLAS_USER, AND ATLAS_KEY env variables'

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -5,6 +5,8 @@ Nose2 Unit Tests for the clusters module.
 """
 from pprint import pprint
 from os import environ, getenv
+
+import atlasapi.errors
 from atlasapi.atlas import Atlas
 from atlasapi.lib import AtlasPeriods, AtlasUnits, AtlasGranularities
 from json import dumps
@@ -117,7 +119,12 @@ class ClusterTests(BaseTests):
     test_10_pause_cluster.advanced = True
 
     def test_11_test_failover(self):
-        self.a.Clusters.test_failover(self.TEST_CLUSTER_NAME)
+        try:
+            self.a.Clusters.test_failover(self.TEST_CLUSTER_NAME)
+        except atlasapi.errors.ErrAtlasBadRequest as e:
+            if e.code == 'CLUSTER_RESTART_IN_PROGRESS':
+                self.assertTrue(True)
+                logger.warning('A cluster retstart was already in effect, so passing this test.')
 
     test_11_test_failover.basic = False
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -7,14 +7,15 @@ from pprint import pprint
 from os import environ, getenv
 
 import atlasapi.specs
+import measurements
 from atlasapi.atlas import Atlas
 from json import dumps
 from tests import BaseTests
 import logging
 from time import sleep
 from atlasapi.lib import AtlasUnits, ClusterType
-from atlasapi.specs import AtlasMeasurement, Host, AtlasPeriods, AtlasGranularities, AtlasMeasurementTypes, \
-    AtlasMeasurementValue, ReplicaSetTypes
+from atlasapi.specs import Host, AtlasPeriods, AtlasGranularities, ReplicaSetTypes
+from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
 from io import BytesIO
 from datetime import datetime, timedelta
 
@@ -64,9 +65,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_03_measurement_stats.basic = True
 
@@ -81,9 +82,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_04_measurement_stats_objects.basic = True
 
@@ -97,12 +98,12 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_05_measurement_stats_objects_returned.basic = True
 
@@ -116,9 +117,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
             print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_06_measurement_stats_cache_bytes_into.basic = True
 
@@ -132,9 +133,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
             print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_07_measurement_stats_cache_bytes_from.basic = True
 
@@ -148,9 +149,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
             print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_08_measurement_stats_cache_dirty.basic = True
 
@@ -164,9 +165,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, atlasapi.specs.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
             print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_09_measurement_stats_cache_used.basic = True
 
@@ -180,9 +181,9 @@ class MeasurementTests(BaseTests):
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
                 print(f'For metric {each.name}')
-                self.assertIsInstance(each.measurement_stats_friendly_number, atlasapi.specs.StatisticalValuesFriendly)
+                self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
                 print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_10_measurement_stats_tickets.basic = True
 
@@ -195,10 +196,10 @@ class MeasurementTests(BaseTests):
             self.a.Hosts.get_measurement_for_hosts(measurement=measurement, granularity=granularity, period=period)
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
-                print(f'For metric {each.name}')
-                self.assertIsInstance(each.measurement_stats_friendly_number, atlasapi.specs.StatisticalValuesFriendly)
+                logger.info(f'For metric {each.name}')
+                self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
                 print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_11_measurement_stats_connections.basic = True
 
@@ -250,9 +251,9 @@ class MeasurementTests(BaseTests):
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
                 print(f'For metric {each.name}')
                 self.assertIsInstance(each.measurement_stats_friendly_number,
-                                      atlasapi.specs.StatisticalValuesFriendly)
+                                      measurements.StatisticalValuesFriendly)
                 print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, atlasapi.specs.StatisticalValues)
+                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     def test_17_return_multiple_metrics(self):
         self.a.Hosts.fill_host_list()
@@ -301,3 +302,12 @@ class MeasurementTests(BaseTests):
                                                            f"returned {type(each_partition)}")
 
     test_21_get_partitions_for_host.basic = True
+
+    def test_22_get_measurements_for_data_partition(self):
+        cluster_name = 'pyAtlasTestCluster'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+        for each_host in self.a.Hosts.host_list:
+            partition_names = each_host.get_partitions(self.a)
+            for each_partition in partition_names:
+                output = each_host.get_measurements_for_disk(self.a, each_partition)
+                pprint(output)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -289,3 +289,15 @@ class MeasurementTests(BaseTests):
             self.assertEqual(cluster_name, each.cluster_name_alias)
 
     test_20_issue_104_hyphen_in_cluster_name.basic = False
+
+    def test_21_get_partitions_for_host(self):
+        cluster_name = 'pyAtlasTestCluster'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+
+        for each_host in self.a.Hosts.host_list:
+            partition_names = each_host.get_partitions(self.a)
+            for each_partition in partition_names:
+                self.assertIsInstance(each_partition, str, f"This should return a partition name as str, instead it "
+                                                           f"returned {type(each_partition)}")
+
+    test_21_get_partitions_for_host.basic = True

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -299,7 +299,7 @@ class MeasurementTests(BaseTests):
 
     test_21_get_partitions_for_host.basic = True
 
-    def test_22_get_measurements_for_data_partition(self):
+    def test_22_get_measurements_for_partition(self):
         cluster_name = 'pyAtlasTestCluster'
         self.a.Hosts.fill_host_list(for_cluster=cluster_name)
         for each_host in self.a.Hosts.host_list:
@@ -310,5 +310,21 @@ class MeasurementTests(BaseTests):
                 for each in output:
                     print('Measurement'.center(80, '*'))
                     print(f"Name: {each.name}: {each.measurement_stats_friendly.mean} {each.units}")
+                    self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
 
-            break
+    test_22_get_measurements_for_partition.basic = True
+
+    def test_23_get_measurements_for_data_partition(self):
+        cluster_name = 'pyAtlasTestCluster'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+        for each_host in self.a.Hosts.host_list:
+            pprint(f"For Host: {each_host.hostname}")
+            output: AtlasMeasurement = each_host.data_partition_stats(self.a)
+            for each in output:
+                print('Measurement'.center(80, '*'))
+                print(f"Name: {each.name}: {each.measurement_stats_friendly.mean} {each.units}")
+                self.assertIsInstance(each.measurement_stats_friendly,
+                                      atlasapi.measurements.StatisticalValuesFriendly)
+
+    test_23_get_measurements_for_data_partition.basic = True
+

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -195,8 +195,8 @@ class MeasurementTests(BaseTests):
             self.a.Hosts.get_measurement_for_hosts(measurement=measurement, granularity=granularity, period=period)
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
-                logger.info(f'For metric {each.name}'.center(80,'*'))
-                logger.info(f'👍Value is {each.measurement_stats}'.center(80,'*'))
+                logger.info(f'For metric {each.name}'.center(80, '*'))
+                logger.info(f'👍Value is {each.measurement_stats}'.center(80, '*'))
                 self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_11_measurement_stats_connections.basic = True
@@ -310,7 +310,8 @@ class MeasurementTests(BaseTests):
                 for each in output:
                     print('Measurement'.center(80, '*'))
                     print(f"Name: {each.name}: {each.measurement_stats_friendly.mean} {each.units}")
-                    self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
+                    self.assertIsInstance(each.measurement_stats_friendly,
+                                          atlasapi.measurements.StatisticalValuesFriendly)
 
     test_22_get_measurements_for_partition.basic = True
 
@@ -328,3 +329,15 @@ class MeasurementTests(BaseTests):
 
     test_23_get_measurements_for_data_partition.basic = True
 
+    def test_24_get_databases(self):
+        cluster_name = 'pyAtlasTestCluster'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+        for each_host in self.a.Hosts.host_list:
+            output = each_host.get_databases(self.a)
+            db_list = []
+            for each_db in output:
+                db_list.append(each_db)
+            print(f'There are are {len(db_list)} dbs on {each_host.hostname_alias}'.center(120, '*'))
+            self.assertGreaterEqual(len(db_list), 2, "There should be at least two datbases on each host!")
+
+    test_24_get_databases.basic = True

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -7,7 +7,7 @@ from pprint import pprint
 from os import environ, getenv
 
 import atlasapi.specs
-import measurements
+import atlasapi.measurements
 from atlasapi.atlas import Atlas
 from json import dumps
 from tests import BaseTests
@@ -15,7 +15,7 @@ import logging
 from time import sleep
 from atlasapi.lib import AtlasUnits, ClusterType
 from atlasapi.specs import Host, AtlasPeriods, AtlasGranularities, ReplicaSetTypes
-from measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
+from atlasapi.measurements import AtlasMeasurementTypes, AtlasMeasurementValue, AtlasMeasurement
 from io import BytesIO
 from datetime import datetime, timedelta
 
@@ -65,9 +65,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_03_measurement_stats.basic = True
 
@@ -82,9 +82,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_04_measurement_stats_objects.basic = True
 
@@ -98,12 +98,12 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly.__dict__}')
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
             print(f'Value is {each.measurement_stats_friendly.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_05_measurement_stats_objects_returned.basic = True
 
@@ -117,9 +117,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
             print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_06_measurement_stats_cache_bytes_into.basic = True
 
@@ -133,9 +133,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
-            print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
+            print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_07_measurement_stats_cache_bytes_from.basic = True
 
@@ -149,9 +149,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
-            print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
+            print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_08_measurement_stats_cache_dirty.basic = True
 
@@ -165,9 +165,9 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
-            print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
-            self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+            self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
+            print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
+            self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_09_measurement_stats_cache_used.basic = True
 
@@ -181,9 +181,8 @@ class MeasurementTests(BaseTests):
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
                 print(f'For metric {each.name}')
-                self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
-                print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+                print(f'👍Value is {each.measurement_stats_friendly}')
+                self.assertIsInstance(each.measurement_stats_friendly, atlasapi.measurements.StatisticalValuesFriendly)
 
     test_10_measurement_stats_tickets.basic = True
 
@@ -196,10 +195,9 @@ class MeasurementTests(BaseTests):
             self.a.Hosts.get_measurement_for_hosts(measurement=measurement, granularity=granularity, period=period)
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
-                logger.info(f'For metric {each.name}')
-                self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
-                print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+                logger.info(f'For metric {each.name}'.center(80,'*'))
+                logger.info(f'👍Value is {each.measurement_stats}'.center(80,'*'))
+                self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     test_11_measurement_stats_connections.basic = True
 
@@ -250,10 +248,8 @@ class MeasurementTests(BaseTests):
             print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
             for each in self.a.Hosts.host_list_with_measurements[0].measurements:
                 print(f'For metric {each.name}')
-                self.assertIsInstance(each.measurement_stats_friendly_number,
-                                      measurements.StatisticalValuesFriendly)
-                print(f'👍Value is {each.measurement_stats_friendly_number.__dict__}')
-                self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
+                print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
+                self.assertIsInstance(each.measurement_stats, atlasapi.measurements.StatisticalValues)
 
     def test_17_return_multiple_metrics(self):
         self.a.Hosts.fill_host_list()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -65,8 +65,8 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
-            print(f'Value is {each.measurement_stats_friendly_bytes.__dict__}')
+            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            print(f'Value is {each.measurement_stats_friendly.__dict__}')
             self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_03_measurement_stats.basic = True
@@ -82,8 +82,8 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
-            print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
+            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            print(f'Value is {each.measurement_stats_friendly.__dict__}')
             self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_04_measurement_stats_objects.basic = True
@@ -98,11 +98,11 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
-            print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
+            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            print(f'Value is {each.measurement_stats_friendly.__dict__}')
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_number, measurements.StatisticalValuesFriendly)
-            print(f'Value is {each.measurement_stats_friendly_number.__dict__}')
+            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            print(f'Value is {each.measurement_stats_friendly.__dict__}')
             self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_05_measurement_stats_objects_returned.basic = True
@@ -117,8 +117,8 @@ class MeasurementTests(BaseTests):
         print(f'For {self.a.Hosts.host_list_with_measurements.__len__()} hosts:')
         for each in self.a.Hosts.host_list_with_measurements[0].measurements:
             print(f'For metric {each.name}')
-            self.assertIsInstance(each.measurement_stats_friendly_bytes, measurements.StatisticalValuesFriendly)
-            print(f'👍Value is {each.measurement_stats_friendly_bytes.__dict__}')
+            self.assertIsInstance(each.measurement_stats_friendly, measurements.StatisticalValuesFriendly)
+            print(f'👍Value is {each.measurement_stats_friendly.__dict__}')
             self.assertIsInstance(each.measurement_stats, measurements.StatisticalValues)
 
     test_06_measurement_stats_cache_bytes_into.basic = True
@@ -307,7 +307,12 @@ class MeasurementTests(BaseTests):
         cluster_name = 'pyAtlasTestCluster'
         self.a.Hosts.fill_host_list(for_cluster=cluster_name)
         for each_host in self.a.Hosts.host_list:
+            pprint(f"For Host: {each_host.hostname}")
             partition_names = each_host.get_partitions(self.a)
             for each_partition in partition_names:
-                output = each_host.get_measurements_for_disk(self.a, each_partition)
-                pprint(output)
+                output: AtlasMeasurement = each_host.get_measurements_for_disk(self.a, each_partition)
+                for each in output:
+                    print('Measurement'.center(80, '*'))
+                    print(f"Name: {each.name}: {each.measurement_stats_friendly.mean} {each.units}")
+
+            break

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -341,3 +341,17 @@ class MeasurementTests(BaseTests):
             self.assertGreaterEqual(len(db_list), 2, "There should be at least two datbases on each host!")
 
     test_24_get_databases.basic = True
+
+    def test_25_get_measurements_for_configdb(self):
+        cluster_name = 'pyAtlasTestCluster'
+        self.a.Hosts.fill_host_list(for_cluster=cluster_name)
+        for each_host in self.a.Hosts.host_list:
+            pprint(f"For Host: {each_host.hostname}")
+            output: AtlasMeasurement = each_host.get_measurements_for_database(self.a, database_name="sample_airbnb")
+            for each in output:
+                print('Measurement'.center(80, '*'))
+                print(f"Name: {each.name}: {each.measurement_stats_friendly.mean} {each.units}")
+                self.assertIsInstance(each.measurement_stats_friendly,
+                                      atlasapi.measurements.StatisticalValuesFriendly)
+
+    test_25_get_measurements_for_configdb.basic = True


### PR DESCRIPTION
## Issue #92 

Work for issue #92, added both the get all databases as well as get metrics for database.

Added the database metrics to the Measurements class as well.

Currently only getting all metrics for database is supported. if there is need to pull individual metrics, perhaps we can add that later.

--- 

##  Issue #100
As part of completing #100 needed to refactor quite a bit with measurements, including:

- grabbing the unit description from the API
- Changing the _friendly method to use the unit description to properly render bytes of numbers.
- Moved measurements classes to its own module (`measurements.py`)
- had to refactor tests

