### PR TITLE
fix(settings): allow `URI_STUB` to be set in the environment to set its value on-the-fly

### DIFF
--- a/atlasapi/__init__.py
+++ b/atlasapi/__init__.py
@@ -15,4 +15,4 @@
 # __init__.py
 
 # Version of the realpython-reader package
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -24,7 +24,7 @@ from os import getenv
 class Settings:
     # Atlas APIs
     BASE_URL = getenv('BASE_URL', 'https://cloud.mongodb.com')
-    URI_STUB = '/api/atlas/v1.0'
+    URI_STUB = getenv('URI_STUB', '/api/atlas/v1.0'))
 
     api_resources = {
         "Project": {

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='atlasapi',
-    version='2.0.1',
+    version='2.0.2',
     python_requires='>=3.7',
     packages=find_packages(exclude=("tests",)),
     install_requires=['requests', 'python-dateutil', 'isodate', 'future', 'pytz','coolname', 'humanfriendly', 'nose'],


### PR DESCRIPTION
This change would allow a user to do something like the following, just before making the API call, allowing them to specify the `URI_STUB` manually for endpoints that accept something other than v1.5 (for example:
https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/returnOneAdvancedClusterFromOneProject)

You could then do something like this to change the value before making the call:

```python
import os

os.environ["URI_STUB"] = "/api/atlas/v1.5"
atlas.Clusters.get_single_cluster(cluster_name) # would now be using a different URI_STUB behind the scenes
```

To set if back, the user can just clear the environment variable, or manually revert it to `"/api/atlas/v1.0"`.