### PR TITLE
fix regression : Add /group in "Modify a Cluster" URI

### DIFF
--- a/atlasapi/settings.py
+++ b/atlasapi/settings.py
@@ -67,7 +67,7 @@ class Settings:
             "Get a Single Cluster": URI_STUB + "/groups/%s/clusters/%s",
             "Delete a Cluster": URI_STUB + "/groups/%s/clusters/%s",
             "Create a Cluster": URI_STUB + "/groups/{GROUP_ID}/clusters/",
-            "Modify a Cluster": URI_STUB + "/{GROUP_ID}/clusters/{CLUSTER_NAME}",
+            "Modify a Cluster": URI_STUB + "/groups/{GROUP_ID}/clusters/{CLUSTER_NAME}",
             "Test Failover": URI_STUB + "/groups/{GROUP_ID}/clusters/{CLUSTER_NAME}/restartPrimaries",
             "Advanced Configuration Options": URI_STUB + "/groups/{GROUP_ID}/clusters/{CLUSTER_NAME}/processArgs",
 


### PR DESCRIPTION
Hello,

With the commit [fbc0ce90d542ee6af8cc3df83340477821e8a1d8](https://github.com/mgmonteleone/python-atlasapi/commit/fbc0ce90d542ee6af8cc3df83340477821e8a1d8) you introduced a bug. The **/group/** in the URL is missing.

This PR put back the /group/, nothing more :)

